### PR TITLE
feat(doctor): offline diagnostics for a silent install

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -138,7 +138,7 @@ ADR: [0006](adr/0006-cli-and-plugin-surface.md). Nine commands; harness identifi
 | `trust` | Grant the current repo's Project-shared tier (path-once registry). |
 | `advise [rule-name] [--harness]` | The Advisor. No argument audits every rule in every tier; a rule name scopes to one. |
 | `import hookify [path]` | One-shot upstream-hookify converter (section 9). |
-| `doctor` | Offline-only: binary location and version; per harness, hook entries present, current, pointing at an existing executable; the current repo's tier discovery, trust state, `local/` exclusion line; rule validity summary. |
+| `doctor` | Offline-only: binary location and version; per harness, hook entries present, current, pointing at an existing executable; the current repo's tier discovery, trust state, `local/` exclusion line; rule validity summary. Exit 1 when any check fails. |
 | `version` | Version, commit, date (GoReleaser-injected). |
 
 - **`--json`** on `advise`, `check`, `test`:

--- a/internal/harness/sync.go
+++ b/internal/harness/sync.go
@@ -56,18 +56,9 @@ func (a Adapter) ConfigPath() string {
 // several.
 func (a Adapter) Install(bin string) (entries int, changed bool, err error) {
 	path := a.ConfigPath()
-	if path == "" {
-		return 0, false, errors.New("no home directory: set HOME")
-	}
-	old, err := os.ReadFile(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	old, settings, err := a.read()
+	if err != nil {
 		return 0, false, err
-	}
-	settings := map[string]any{}
-	if len(old) > 0 {
-		if err := json.Unmarshal(old, &settings); err != nil {
-			return 0, false, fmt.Errorf("%s: %w", path, err)
-		}
 	}
 
 	hooks, _ := settings["hooks"].(map[string]any)
@@ -82,7 +73,7 @@ func (a Adapter) Install(bin string) (entries int, changed bool, err error) {
 		hooks[event] = append(groups, map[string]any{
 			"hooks": []any{map[string]any{
 				"type":    "command",
-				"command": shellQuote(bin) + " hook " + a.Name + " " + event,
+				"command": a.command(bin, event),
 			}},
 		})
 	}
@@ -101,16 +92,84 @@ func (a Adapter) Install(bin string) (entries int, changed bool, err error) {
 	return len(events), true, write(path, next)
 }
 
-// ours reports whether command is an entry a previous sync wrote for event. The
-// binary's directory is not part of the test, so a moved binary replaces its old
-// entry instead of stacking a second one; its name is, so nothing of the user's
-// own can be deleted from their settings by resembling handrail's command line.
-func (a Adapter) ours(command, event string) bool {
+// read parses the harness's config, returning the bytes it came from so Install
+// can tell an unchanged file from a rewritten one. A file that is not there yet
+// is an empty config, not a failure.
+func (a Adapter) read() (raw []byte, settings map[string]any, err error) {
+	path := a.ConfigPath()
+	if path == "" {
+		return nil, nil, errors.New("no home directory: set HOME")
+	}
+	raw, err = os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, nil, err
+	}
+	settings = map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &settings); err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", path, err)
+		}
+	}
+	return raw, settings, nil
+}
+
+// command is the hook entry sync writes for one event, and therefore the one
+// doctor compares against what it finds installed.
+func (a Adapter) command(bin, event string) string {
+	return shellQuote(bin) + " hook " + a.Name + " " + event
+}
+
+// entryBinary reads the binary invoked by a command line, when that command
+// line is one a previous sync wrote for event. The binary's directory is not
+// part of the test, so a moved binary replaces its old entry instead of stacking
+// a second one; its name is, so nothing of the user's own can be deleted from
+// their settings by resembling handrail's command line.
+func (a Adapter) entryBinary(command, event string) (string, bool) {
 	tail, found := strings.CutSuffix(command, " hook "+a.Name+" "+event)
 	if !found {
-		return false
+		return "", false
 	}
-	return strings.HasPrefix(filepath.Base(strings.Trim(tail, "'")), "handrail")
+	bin := shellUnquote(tail)
+	if !strings.HasPrefix(filepath.Base(bin), "handrail") {
+		return "", false
+	}
+	return bin, true
+}
+
+// Entries reports the binary each canonical event's installed hook entry
+// invokes, in the order sync wrote them. An event handrail has no entry for
+// comes back empty, which is what doctor calls a missing entry.
+func (a Adapter) Entries() ([]Entry, error) {
+	_, settings, err := a.read()
+	if err != nil {
+		return nil, err
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	events := rule.Events()
+	out := make([]Entry, 0, len(events))
+	for _, event := range events {
+		e := Entry{Event: event}
+		groups, _ := hooks[event].([]any)
+		for _, g := range groups {
+			group, _ := g.(map[string]any)
+			inner, _ := group["hooks"].([]any)
+			for _, h := range inner {
+				hook, _ := h.(map[string]any)
+				cmd, _ := hook["command"].(string)
+				if bin, ok := a.entryBinary(cmd, event); ok {
+					e.Binary = bin
+				}
+			}
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// Entry is one event's installed hook entry, as doctor found it.
+type Entry struct {
+	Event  string
+	Binary string // the binary the entry invokes, empty when there is no entry
 }
 
 // prune drops the entries a previous sync wrote for event. An entry pointing at
@@ -131,9 +190,9 @@ func (a Adapter) prune(groups any, event string) []any {
 		}
 		keptInner := make([]any, 0, len(inner))
 		for _, h := range inner {
-			hook, ok := h.(map[string]any)
-			if ok {
-				if cmd, _ := hook["command"].(string); a.ours(cmd, event) {
+			if hook, ok := h.(map[string]any); ok {
+				cmd, _ := hook["command"].(string)
+				if _, ours := a.entryBinary(cmd, event); ours {
 					continue
 				}
 			}
@@ -188,6 +247,14 @@ func shellQuote(s string) string {
 		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// shellUnquote undoes shellQuote, so doctor can stat the binary an entry names.
+func shellUnquote(s string) string {
+	if len(s) < 2 || !strings.HasPrefix(s, "'") || !strings.HasSuffix(s, "'") {
+		return s
+	}
+	return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
 }
 
 // Degradation is one rule this harness cannot enforce at full strength.

--- a/internal/rule/exclude.go
+++ b/internal/rule/exclude.go
@@ -12,23 +12,50 @@ import (
 // excludeLine keeps the Project-personal tier out of version control.
 const excludeLine = ".handrail/local/"
 
+// readExclude reads root's exclude file and names it. Outside a git working
+// tree there is no such file, and the empty path says so: that is not the same
+// as a file whose line went missing, which is the distinction doctor reports on.
+func readExclude(root string) (path string, data []byte, err error) {
+	git, err := gitDir(root)
+	if err != nil || git == "" {
+		return "", nil, err
+	}
+	path = filepath.Join(git, "info", "exclude")
+	data, err = os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", nil, err
+	}
+	return path, data, nil
+}
+
+// hasExcludeLine reports whether an exclude file's contents already hold it.
+func hasExcludeLine(data []byte) bool {
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if strings.TrimSpace(line) == excludeLine {
+			return true
+		}
+	}
+	return false
+}
+
+// LocalExcluded reports whether root's exclude file holds the line, and names
+// the file it read. An empty path means root is not a git working tree, where
+// there is nothing to exclude and therefore nothing missing.
+func LocalExcluded(root string) (excluded bool, path string, err error) {
+	path, data, err := readExclude(root)
+	if err != nil || path == "" {
+		return false, "", err
+	}
+	return hasExcludeLine(data), path, nil
+}
+
 // ExcludeLocal adds the Project-personal tier to root's own exclude file,
 // reporting whether that was new. info/exclude rather than .gitignore: the tier
 // is one user's, and the ignore rule for it is nobody else's business.
 func ExcludeLocal(root string) (added bool, err error) {
-	git, err := gitDir(root)
-	if err != nil || git == "" {
+	path, data, err := readExclude(root)
+	if err != nil || path == "" || hasExcludeLine(data) {
 		return false, err
-	}
-	path := filepath.Join(git, "info", "exclude")
-	data, err := os.ReadFile(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return false, err
-	}
-	for line := range strings.SplitSeq(string(data), "\n") {
-		if strings.TrimSpace(line) == excludeLine {
-			return false, nil
-		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -37,7 +37,7 @@ type Discovery struct {
 func LoadTiers(cwd string) ([]*Rule, []Problem, Discovery) {
 	root := RepoRoot(cwd)
 	d := Discovery{Root: root}
-	shared := filepath.Join(root, ".handrail")
+	shared := SharedDir(root)
 
 	var rules []*Rule
 	var problems []Problem
@@ -66,7 +66,7 @@ func LoadTiers(cwd string) ([]*Rule, []Problem, Discovery) {
 		d.Skipped = true
 		problems = append(problems, ps...)
 	}
-	add(TierProjectPersonal, filepath.Join(shared, "local"), false)
+	add(TierProjectPersonal, LocalDir(root), false)
 
 	// Identity is the basename, so the highest tier holding a name carries the
 	// effective rule and every lower one is shadowed by it, wholesale.
@@ -81,6 +81,13 @@ func LoadTiers(cwd string) ([]*Rule, []Problem, Discovery) {
 	}
 	return rules, problems, d
 }
+
+// SharedDir is the Project-shared tier's directory, at the project root.
+func SharedDir(root string) string { return filepath.Join(root, ".handrail") }
+
+// LocalDir is the Project-personal tier's directory, inside the shared one so a
+// single exclude line keeps it out of version control.
+func LocalDir(root string) string { return filepath.Join(SharedDir(root), "local") }
 
 // ConfigDir is the Global tier's directory: XDG on every Unix platform,
 // including macOS, following the git and gh dotfiles precedent rather than

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ Commands:
   trust     Grant this repo's Project-shared rules
   advise    Recommend native harness entries for the rules that translate
   import    Convert upstream hookify rules into Project-personal rules
+  doctor    Diagnose this machine's install, offline
   version   Print version, commit, and build date
 `
 
@@ -76,6 +77,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return cmdAdvise(args[1:], stdout, stderr)
 	case "import":
 		return cmdImport(args[1:], stdout, stderr)
+	case "doctor":
+		return cmdDoctor(args[1:], stdout, stderr)
 	case "version":
 		return cmdVersion(args[1:], stdout, stderr)
 	default:
@@ -93,6 +96,185 @@ func cmdVersion(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "handrail %s\ncommit: %s\ndate: %s\n", version, commit, date)
 	return 0
+}
+
+// cmdDoctor is the first command for "why is nothing firing". Everything it
+// checks is already on this machine, so it answers with no network at all: the
+// binary answering, each harness's hook entries, this repo's tiers, trust state
+// and exclusion line, and whether the rules parse. It exits 1 when anything is
+// wrong, so the answer is actionable without reading the report.
+func cmdDoctor(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "handrail doctor: unexpected argument %q\n", fs.Arg(0))
+		return 1
+	}
+
+	r := &report{w: stdout}
+
+	bin, err := os.Executable()
+	if err != nil {
+		r.bad("cannot locate this binary: %v", err)
+	} else {
+		r.ok("handrail %s at %s", version, bin)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(stderr, "handrail: %v\n", err)
+		return 1
+	}
+	rules, ruleProblems, d := rule.LoadTiers(cwd)
+
+	for _, a := range harness.Adapters() {
+		fmt.Fprintln(stdout)
+		if !a.Installed() {
+			r.note("%s: not installed", a.Name)
+			continue
+		}
+		r.ok("%s: config at %s", a.Name, a.ConfigPath())
+		r.checkEntries(a, bin)
+		// Degradation is reported at sync time and reprintable here: a rule
+		// weakened months ago is exactly the kind that reads as not firing.
+		for _, deg := range a.Degradations(rules) {
+			r.note("%s: %s", a.Name, deg)
+		}
+		for _, q := range a.Quirks {
+			r.note("%s: %s", a.Name, q)
+		}
+	}
+
+	fmt.Fprintln(stdout)
+	r.ok("project root %s", d.Root)
+	r.checkTiers(rules, d)
+	r.checkExclusion(d.Root)
+
+	for _, p := range ruleProblems {
+		r.bad("%s: %s", p.Path, p.Message)
+	}
+	r.ok("%s valid", countRules(len(rules)))
+
+	if r.problems > 0 {
+		return 1
+	}
+	return 0
+}
+
+// report is doctor's output, and the count of faults among it that the exit
+// code answers for. A problem is something the user can fix; a note is
+// something they can only know. Both belong in the report, and only one of
+// them is a fault.
+type report struct {
+	w        io.Writer
+	problems int
+}
+
+func (r *report) line(status, format string, a ...any) {
+	fmt.Fprintf(r.w, "%-8s %s\n", status, fmt.Sprintf(format, a...))
+}
+
+func (r *report) ok(format string, a ...any)   { r.line("ok", format, a...) }
+func (r *report) note(format string, a ...any) { r.line("note", format, a...) }
+
+func (r *report) bad(format string, a ...any) {
+	r.problems++
+	r.line("problem", format, a...)
+}
+
+// checkEntries answers the question a broken install turns into: is there an
+// entry for every event, and does it invoke a binary that is here, runnable,
+// and this one? A silent harness usually has one of those four wrong.
+func (r *report) checkEntries(a harness.Adapter, bin string) {
+	entries, err := a.Entries()
+	if err != nil {
+		r.bad("%s: %v", a.Name, err)
+		return
+	}
+	current := 0
+	for _, e := range entries {
+		switch {
+		case e.Binary == "":
+			r.bad("%s: no hook entry for %s; run handrail sync", a.Name, e.Event)
+		case !runnable(e.Binary):
+			// An install that loses the exec bit leaves every entry in place and
+			// every rule unenforced, which is the failure that looks like none.
+			r.bad("%s: the %s entry names %s, which is not a runnable file; run handrail sync",
+				a.Name, e.Event, e.Binary)
+		case e.Binary != bin:
+			r.bad("%s: the %s entry names %s, and this binary is %s; run handrail sync",
+				a.Name, e.Event, e.Binary, bin)
+		default:
+			current++
+		}
+	}
+	if current == len(entries) {
+		r.ok("%s: %d hook entries current", a.Name, current)
+	}
+}
+
+// checkTiers reports what tier discovery found for this working directory, with
+// the directory each tier was read from: a rule in the wrong place and a repo
+// root that is not the one expected look identical from the outside.
+func (r *report) checkTiers(rules []*rule.Rule, d rule.Discovery) {
+	counts := map[string]int{}
+	for _, rl := range rules {
+		counts[rl.Tier]++
+	}
+	if global := rule.ConfigDir(); global == "" {
+		r.bad("%s: no config directory: set HOME or XDG_CONFIG_HOME", rule.TierGlobal)
+	} else {
+		r.ok("%s: %s in %s", rule.TierGlobal, countRules(counts[rule.TierGlobal]), global)
+	}
+
+	shared := rule.SharedDir(d.Root)
+	if d.Skipped {
+		r.bad("%s: %s holds rules this machine has not trusted; run handrail trust",
+			rule.TierProjectShared, shared)
+	} else {
+		trusted := ""
+		if rule.IsTrusted(d.Root) {
+			trusted = ", trusted"
+		}
+		r.ok("%s: %s in %s%s",
+			rule.TierProjectShared, countRules(counts[rule.TierProjectShared]), shared, trusted)
+	}
+
+	r.ok("%s: %s in %s",
+		rule.TierProjectPersonal, countRules(counts[rule.TierProjectPersonal]), rule.LocalDir(d.Root))
+}
+
+// checkExclusion reports the line sync writes to keep the Project-personal tier
+// out of version control. Outside a working tree there is nothing to exclude,
+// which is not the same as an exclusion that went missing.
+func (r *report) checkExclusion(root string) {
+	switch excluded, path, err := rule.LocalExcluded(root); {
+	case err != nil:
+		r.bad("cannot read the exclude file of %s: %v", root, err)
+	case path == "":
+		r.ok("%s is not a git working tree, so nothing needs excluding", root)
+	case excluded:
+		r.ok(".handrail/local/ is excluded in .git/info/exclude")
+	default:
+		r.bad(".handrail/local/ is not excluded in .git/info/exclude; run handrail sync")
+	}
+}
+
+// runnable reports whether a hook entry's binary is a file this machine can
+// execute. A directory or a lost exec bit is a hook entry that fires nothing.
+func runnable(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular() && fi.Mode().Perm()&0o111 != 0
+}
+
+func countRules(n int) string {
+	if n == 1 {
+		return "1 rule"
+	}
+	return fmt.Sprintf("%d rules", n)
 }
 
 func cmdTrust(args []string, stdout, stderr io.Writer) int {

--- a/testdata/script/doctor.txtar
+++ b/testdata/script/doctor.txtar
@@ -1,0 +1,74 @@
+# doctor is the first command for "why is nothing firing". Every answer it gives
+# is already on this machine: it reads files and never a network.
+cd repo
+exec handrail trust
+exec handrail sync
+exec handrail doctor
+! stdout 'problem'
+
+# The binary answering, and the version it is.
+stdout '^ok +handrail dev at /'
+
+# Both harnesses are covered when both are installed, each under its own name.
+stdout '^ok +claude: config at .*/home/\.claude/settings\.json$'
+stdout '^ok +claude: 6 hook entries current$'
+stdout '^ok +codex: config at .*/home/\.codex/hooks\.json$'
+stdout '^ok +codex: 6 hook entries current$'
+
+# Degradations and fail-open quirks are reprintable here, not only at sync time.
+stdout '^note +claude: block degraded to warn for late: Claude Code has no denial to give on PostToolUse$'
+stdout '^note +claude: hook errors and timeouts fail open'
+stdout '^note +codex: codex exec --ignore-rules bypasses execpolicy'
+! stdout 'claude: codex exec'
+
+# Tier discovery for the current repo, with the directory each tier was read
+# from: a wrong root is the other half of "why is nothing firing".
+stdout '^ok +project root .*/repo$'
+stdout '^ok +global: 1 rule in .*/home/\.config/handrail$'
+stdout '^ok +project-shared: 2 rules in .*/repo/\.handrail, trusted$'
+stdout '^ok +project-personal: 1 rule in .*/repo/\.handrail/local$'
+
+# The exclusion line sync writes, and the ruleset's validity.
+stdout '^ok +\.handrail/local/ is excluded in \.git/info/exclude$'
+stdout '^ok +4 rules valid$'
+
+# A harness that has never run on this machine is a fact, not a fault.
+mv $WORK/home/.codex $WORK/home/.codex-gone
+exec handrail doctor
+stdout '^note +codex: not installed$'
+! stdout 'problem'
+! stdout 'codex: 6 hook entries'
+
+# Outside a git working tree there is nothing to exclude, so nothing is wrong.
+cd $WORK
+exec handrail doctor
+! stdout 'problem'
+stdout 'is not a git working tree, so nothing needs excluding'
+
+-- home/.claude/settings.json --
+{}
+-- home/.codex/hooks.json --
+{}
+-- home/.config/handrail/global.md --
+---
+event: PreToolUse
+---
+A rule every repo on this machine carries.
+-- repo/.git/HEAD --
+ref: refs/heads/main
+-- repo/.handrail/late.md --
+---
+event: PostToolUse
+action: block
+---
+Claude Code cannot undo a tool call that already ran.
+-- repo/.handrail/shared.md --
+---
+event: PreToolUse
+---
+A committed rule, granted by trust.
+-- repo/.handrail/local/mine.md --
+---
+event: PreToolUse
+---
+The user's own rule.

--- a/testdata/script/doctor_broken.txtar
+++ b/testdata/script/doctor_broken.txtar
@@ -1,0 +1,112 @@
+# Every state that keeps a rule from firing is named, and doctor exits nonzero
+# so a script can act on it. The template carries the sandbox's own path,
+# because an entry's binary is only stale relative to the one running.
+exec sh -c 'sed "s|WORKDIR|$WORK|" $WORK/home/.claude/settings.json > $WORK/next.json && mv $WORK/next.json $WORK/home/.claude/settings.json'
+chmod 0755 moved/handrail
+exec sh -c 'handrail doctor; echo code=$?'
+stdout '^code=1$'
+
+# An entry naming a binary that is not this one enforces the wrong handrail.
+stdout '^problem +claude: the PreToolUse entry names .*/moved/handrail, and this binary is /.*; run handrail sync$'
+
+# An entry naming a binary that is gone enforces nothing at all.
+stdout '^problem +claude: the PostToolUse entry names /nowhere/handrail, which is not a runnable file; run handrail sync$'
+
+# An event with no entry of handrail's is the plainest reason nothing fires,
+# and another tool's entry on that event is not one of handrail's.
+stdout '^problem +claude: no hook entry for UserPromptSubmit; run handrail sync$'
+stdout '^problem +claude: no hook entry for SessionStart; run handrail sync$'
+stdout '^problem +claude: no hook entry for SessionEnd; run handrail sync$'
+stdout '^problem +claude: no hook entry for Stop; run handrail sync$'
+! stdout 'hook entries current'
+
+# A harness with no install is reported, not diagnosed.
+stdout '^note +codex: not installed$'
+
+# Committed rules nobody granted are skipped, which reads as silence otherwise.
+stdout '^problem +project-shared: .*/\.handrail holds rules this machine has not trusted; run handrail trust$'
+
+# Keeping the Project-personal tier out of version control is sync's doing, so
+# its absence is sync's to fix.
+stdout '^problem +\.handrail/local/ is not excluded in \.git/info/exclude; run handrail sync$'
+
+# A rule that cannot be parsed guards nothing, and doctor names the file.
+stdout '^problem +.*/broken\.md: line 2: unknown event "Nope"$'
+stdout '^ok +1 rule valid$'
+
+# An entry whose exec bit an install lost fires nothing either, and it looks
+# exactly like a working entry from the settings file alone.
+chmod 0644 moved/handrail
+exec sh -c 'handrail doctor; echo code=$?'
+stdout '^code=1$'
+stdout '^problem +claude: the PreToolUse entry names .*/moved/handrail, which is not a runnable file; run handrail sync$'
+
+# Fixing what sync and trust own turns those checks green.
+rm .handrail/local/broken.md
+exec handrail trust
+exec handrail sync
+exec handrail doctor
+stdout '^ok +claude: 6 hook entries current$'
+stdout '^ok +project-shared: 1 rule in .*/\.handrail, trusted$'
+stdout '^ok +\.handrail/local/ is excluded in \.git/info/exclude$'
+! stdout 'problem'
+
+# An unreadable harness config is a diagnosis of its own, not a crash.
+exec sh -c 'echo not json > $WORK/home/.claude/settings.json'
+! exec handrail doctor
+stdout '^problem +claude: '
+
+-- .git/HEAD --
+ref: refs/heads/main
+-- moved/handrail --
+a binary that is not the one running
+-- home/.claude/settings.json --
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "WORKDIR/moved/handrail hook claude PreToolUse"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/nowhere/handrail hook claude PostToolUse"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "my-own.sh hook claude SessionStart"
+          }
+        ]
+      }
+    ]
+  }
+}
+-- .handrail/shared.md --
+---
+event: PreToolUse
+---
+A committed rule nobody has granted yet.
+-- .handrail/local/broken.md --
+---
+event: Nope
+---
+A rule that cannot be parsed guards nothing.
+-- .handrail/local/mine.md --
+---
+event: PreToolUse
+---
+The user's own rule.

--- a/testdata/script/no_home.txtar
+++ b/testdata/script/no_home.txtar
@@ -24,6 +24,13 @@ exec sh -c 'handrail sync; echo code=$?'
 stdout '^code=1$'
 stderr 'no harness found'
 
+# doctor answers the same way: nowhere to read a Global tier from is a fault it
+# names, not a directory it invents.
+exec sh -c 'handrail doctor; echo code=$?'
+stdout '^code=1$'
+stdout '^problem +global: no config directory: set HOME or XDG_CONFIG_HOME$'
+stdout '^note +claude: not installed$'
+
 # With home set and no XDG variable, the base is the spec's default under it.
 env HOME=$WORK/home
 mkdir $WORK/home/.config/handrail

--- a/testdata/script/sync_gitdir.txtar
+++ b/testdata/script/sync_gitdir.txtar
@@ -13,6 +13,16 @@ exec sh -c 'cd empty-pointer && handrail sync; echo code=$?'
 stdout '^code=1$'
 stderr 'names no git directory'
 
+# doctor reads the same shapes, and says what it could not read rather than
+# calling the exclusion missing.
+exec sh -c 'cd empty-pointer && handrail doctor; echo code=$?'
+stdout '^code=1$'
+stdout '^problem +cannot read the exclude file of .*: .* names no git directory$'
+
+exec sh -c 'cd exclude-is-a-dir && handrail doctor; echo code=$?'
+stdout '^code=1$'
+stdout '^problem +cannot read the exclude file of .*: '
+
 # A relative pointer resolves against the working tree, and its commondir hop
 # lands the line in the main checkout's exclude file.
 exec sh -c 'cd worktree && handrail sync'

--- a/testdata/script/usage.txtar
+++ b/testdata/script/usage.txtar
@@ -24,6 +24,10 @@ exec sh -c 'handrail hook -nope; echo code=$?'
 stdout '^code=1$'
 stderr 'flag provided but not defined: -nope'
 
+exec sh -c 'handrail doctor -nope; echo code=$?'
+stdout '^code=1$'
+stderr 'flag provided but not defined: -nope'
+
 # import's format leads, so the flag is parsed after it.
 exec sh -c 'handrail import hookify -nope; echo code=$?'
 stdout '^code=1$'
@@ -42,6 +46,10 @@ stderr 'handrail check: unexpected argument "extra"'
 exec sh -c 'handrail sync extra; echo code=$?'
 stdout '^code=1$'
 stderr 'handrail sync: unexpected argument "extra"'
+
+exec sh -c 'handrail doctor extra; echo code=$?'
+stdout '^code=1$'
+stderr 'handrail doctor: unexpected argument "extra"'
 
 # advise takes one positional, the rule name, so the second one is the leftover.
 exec sh -c 'handrail advise some-rule extra; echo code=$?'


### PR DESCRIPTION
`handrail doctor` answers "why is nothing firing" from what is already on this
machine. It reads files and never a network, so it works on a plane and in a
sandbox.

## What it checks

- The binary and version answering, and where it lives.
- Per installed harness: one hook entry per canonical event, and whether that
  entry names *this* binary and a file that is runnable. A lost exec bit leaves
  every entry in place and every rule unenforced, which is the failure that
  looks like none.
- Degradations and fail-open quirks, reprinted here rather than only at sync
  time: a rule weakened months ago is exactly the kind that reads as silence.
- This repo's tier discovery, with the directory each tier was read from. A rule
  in the wrong place and a repo root that is not the expected one look identical
  from the outside.
- Trust state for the Project-shared tier, and the `.handrail/local/` exclusion
  line sync writes.
- Whether the rules parse, naming the file for each that does not.

Each problem carries the command that fixes it, and doctor exits 1 when it finds
one, so a script can act on the answer without reading it.

## Spec

Section 6's `doctor` row gains "Exit 1 when any check fails", making explicit
what was already implied by the row's "validation error" exit code.

## Supporting changes

- `harness.Adapter` gains `Entries()`, reading back the hook entries a previous
  sync wrote. `Install` and `prune` now share the config read and the
  command-line parse with it instead of keeping their own copies.
- `rule.LocalExcluded` reports whether the exclusion line is present and names
  the file it read; an empty path distinguishes "not a git working tree" from
  "the line went missing".
- `rule.SharedDir` and `rule.LocalDir` name the tier directories that
  `LoadTiers` was computing inline.

## Tests

`testdata/script/doctor.txtar` covers the healthy sandbox with both harnesses
present, and the out-of-repo case. `doctor_broken.txtar` covers every broken
state named in the issue plus the repair that turns them green: a stale entry, a
gone binary, a lost exec bit, missing entries, another tool's entry correctly
left alone, an untrusted repo, a missing exclusion line, an invalid rule, and an
unreadable harness config.

Closes #27