### PR TITLE
feat(release): GoReleaser pipeline, tap cask, and a config check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,18 @@ jobs:
 
       - name: Lint and formatting
         run: task lint
+
+  release-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # install-only, so the check runs through the Taskfile like every other
+      # step, and `task release-check` locally is the same command.
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          install-only: true
+      - uses: go-task/setup-task@v2
+
+      - name: Validate the release config
+        run: task release-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+# A release must never be cancelled halfway through uploading its assets.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # create the release and upload assets
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # goreleaser reads tag history to build the changelog
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A repo-scoped PAT: GITHUB_TOKEN cannot write to the tap repo.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # Coverage profile, written by task cover
 /cover.out
+
+# Release artifacts, written by goreleaser
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,52 @@
+version: 2
+
+builds:
+  - binary: handrail
+    env:
+      - CGO_ENABLED=0
+    # The three vars main.go declares. Nothing else is injected: handrail has no
+    # third-party runtime dependencies to stamp a builder into.
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+# Both names below are what the plugin bootstrap downloads and verifies against
+# (spec section 7), so they are a contract with it rather than defaults worth
+# re-deriving: the archive template is also the field whose shape changed
+# between GoReleaser v1 and v2.
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+# A tag like v0.1.0-rc.1 must not become the repo's latest release: the default
+# is prerelease false, which would publish the pipeline's own proving run as v1.
+release:
+  prerelease: auto
+
+homebrew_casks:
+  - name: handrail
+    description: "Cross-harness guardrail manager for agentic coding harnesses"
+    homepage: "https://github.com/svyatov/handrail"
+    binaries:
+      - handrail
+    # Gatekeeper quarantines anything curl'd, and an unsigned binary that dies
+    # on first run reads as a broken install rather than a signing decision.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/handrail"]
+          end
+    repository:
+      owner: svyatov
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,3 +48,8 @@ tasks:
     cmds:
       - golangci-lint run
       - golangci-lint fmt --diff
+
+  release-check:
+    desc: Validate .goreleaser.yml, so a bad config fails here rather than on a tag
+    cmds:
+      - goreleaser check


### PR DESCRIPTION
Closes #28.

## What changed

A tag push on `v*` now builds darwin and linux on amd64 and arm64, stamps `main.version`, `main.commit`, and `main.date` through `-ldflags`, publishes the four tar.gz archives plus `checksums.txt` to GitHub Releases, and pushes a cask to `svyatov/homebrew-tap`. `go install` keeps working unchanged: the binary is still a root main package.

CI gains a `release-config` job that runs `task release-check` (`goreleaser check`), so a broken config fails on a pull request rather than on a tag. It runs a Taskfile task for the same reason every other CI step does, and installs goreleaser install-only for the same reason the lint job installs golangci-lint that way.

## Two defaults pinned on purpose

The plugin bootstrap in #29 downloads an archive by name and verifies it against `checksums.txt` (spec section 7), so both names are a contract with it rather than preferences. The archive `name_template` in particular is the field whose shape changed between GoReleaser v1 and v2, which is exactly the kind of default that should not be inherited silently. The pinned template produces the same filenames the v2 default did, verified against a local snapshot build.

`release: prerelease: auto` is pinned because the pipeline is proven with an rc tag, and the default (`prerelease: false`, `make_latest: true`) would publish that proving run as the repository's latest release.

## Verification

`goreleaser check` passes, and `goreleaser release --snapshot --clean --skip=homebrew` produced exactly four archives plus `checksums.txt`, with the darwin/arm64 binary printing an injected version, commit, and date. `task lint` is clean and `task cover` sits at 97.6%.

## Not done here

The tap push needs a `HOMEBREW_TAP_TOKEN` repository secret, since `GITHUB_TOKEN` cannot write to another repository. It is not set yet, and no tag is being cut in this PR, so the three acceptance criteria that need a published release (artifacts on GitHub Releases, `brew install` from the tap, `go install @<tag>`) stay open until then.

SBOM generation and build provenance attestation are deliberately absent: #16 puts oss-kit treatment beyond the pipeline itself after v1.