### PR TITLE
chore: licence the repository and keep pre-releases out of the tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,10 @@ homebrew_casks:
     homepage: "https://github.com/svyatov/handrail"
     binaries:
       - handrail
+    # The tap is public and holds one cask per project, so an rc pushed into it
+    # is what every `brew install` gets until the next tag. auto skips the
+    # commit whenever the tag carries a prerelease indicator.
+    skip_upload: auto
     # Gatekeeper quarantines anything curl'd, and an unsigned binary that dies
     # on first run reads as a broken install rather than a signing decision.
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Leonid Svyatov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Two changes that both block making this repository public.

## MIT licence

Source published without a licence is all rights reserved: nobody may legally use, copy, or modify it, which is the opposite of what distributing through a Homebrew tap and `go install` is for. MIT matches `oz`, `oss-kit`, `yard`, and `sec_id`. GoReleaser's default archive file globs pick `LICENSE` up, so it also starts shipping inside the release archives.

## No cask for pre-release tags

Proving the pipeline with `v0.1.0-rc.1` pushed a cask into `svyatov/homebrew-tap`. The tap is public and holds one cask per project, so that rc became what every `brew install svyatov/tap/handrail` would get until the next tag, and every URL in it pointed at a private repository's release assets, so they answered 404 to everyone.

`skip_upload: auto` skips the tap commit whenever the tag carries a prerelease indicator. That is what a tap wants regardless of who can read the assets: a tap should carry stable versions, not release candidates.

## What the rc did prove

Publishing worked. The release carries four archives plus `checksums.txt`, `prerelease: auto` flagged it correctly so `/releases/latest` still 404s, and a downloaded darwin/arm64 binary verified against `checksums.txt` printed its injected version, commit, and date. What it could not prove is `brew install` and `go install`, both of which need the repository to be public.