### PR TITLE
feat(plugin): Claude Code plugin with the add skill and a SessionStart bootstrap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "handrail",
+  "description": "handrail's own marketplace: the cross-harness guardrail manager plugin.",
+  "owner": {
+    "name": "Leonid Svyatov",
+    "email": "leonid@svyatov.com"
+  },
+  "plugins": [
+    {
+      "name": "handrail",
+      "source": "./",
+      "description": "Cross-harness guardrail manager: one rule file, enforced in every harness.",
+      "category": "safety"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "handrail",
+  "description": "Declare an agent guardrail once, in one neutral format, and enforce it through every harness's native hooks.",
+  "version": "0.1.0-rc.1",
+  "author": {
+    "name": "Leonid Svyatov",
+    "email": "leonid@svyatov.com"
+  },
+  "homepage": "https://github.com/svyatov/handrail",
+  "repository": "https://github.com/svyatov/handrail",
+  "license": "MIT",
+  "keywords": ["guardrails", "hooks", "safety", "rules"]
+}

--- a/docs/plugin-verification.md
+++ b/docs/plugin-verification.md
@@ -1,0 +1,58 @@
+# Plugin verification
+
+The plugins, the skills, and the bootstrap script sit outside the testscript
+seam ([ADR 0009](adr/0009-testing-strategy.md)), so this checklist is their
+acceptance gate. Re-run it whenever `scripts/bootstrap.sh`, `hooks/hooks.json`,
+or a plugin manifest changes, and record what the run showed.
+
+## Checklist
+
+Run each case against an isolated `HOME`, never the real one, so a failed run
+cannot leave hook entries behind on the machine. Create `$HOME/.claude` in it:
+harness detection reads that path and nothing else, so without it sync finds no
+harness and case 1 cannot pass. Isolate the plugin install with
+`CLAUDE_CONFIG_DIR`, which moves where Claude Code itself stores plugins but,
+per the findings below, does not move where sync looks.
+
+| # | Case | Expected |
+|---|---|---|
+| 1 | Fresh `HOME`, no binary anywhere | The artifact for this OS/arch downloads, its sha256 matches `checksums.txt`, the binary lands in `$XDG_DATA_HOME/handrail/bin/handrail`, and `sync` runs once |
+| 2 | Corrupted archive | Install refused with the expected and actual digest named; no `bin` directory created |
+| 3 | `handrail` on `PATH` | Nothing downloaded, nothing written, exit 0 |
+| 4 | Managed binary at the wrong version | Reinstalled at the pinned version |
+| 5 | Managed binary at the pinned version | Nothing downloaded, exit 0, no output |
+| 6 | Plugin installed from a marketplace | `scripts/bootstrap.sh` survives the copy into the plugin cache and the SessionStart hook fires |
+| 7 | `/handrail:add` from a plain-language description | A rule file that `check` accepts, `test` matches against its own incident, and `advise` reports on |
+
+## 2026-08-18, v0.1.0-rc.1 on darwin/arm64
+
+Cases 1 to 6 pass. Case 2 was driven with a stub `curl` serving a corrupted
+archive; the others hit the real release.
+
+- Case 1: `handrail_0.1.0-rc.1_darwin_arm64.tar.gz` verified and installed, then
+  `sync` wrote six hook entries naming the absolute managed path.
+- Case 6: the plugin installed from a local marketplace clone, `hooks/hooks.json`
+  registered by auto-discovery alone, and the SessionStart hook fired on a
+  headless session, installing the binary at mode `755` and syncing all six
+  entries. Case 7 was exercised command by command (`check`, `test`,
+  `advise --json`) rather than through a live session, because the sandboxed
+  session had no credentials.
+
+### Findings
+
+- **Exec-bit survival**: the execute bit survived the copy into the plugin cache
+  on macOS from a relative-path marketplace source. The hook still invokes the
+  script as `sh "$CLAUDE_PLUGIN_ROOT/scripts/bootstrap.sh"`, since upstream
+  documents nothing here and archive and npm sources are untested.
+- **Per-arch selection**: Claude Code offers no per-OS or per-arch source
+  selection, so the script does its own `uname` dispatch. Confirmed by
+  installing one plugin copy that works on either architecture.
+- **Repo root is the plugin root**, so that both plugin manifests can reference
+  one `skills/` directory (a copied plugin cannot reference `../`). The cost is
+  one warning from `claude plugin validate --strict`: a `CLAUDE.md` at the plugin
+  root is not loaded as plugin context. That file is the repo's own agent
+  instructions and is meant to stay; the warning is expected.
+- **`CLAUDE_CONFIG_DIR` is not honored by sync.** Harness detection looks at
+  `~/.claude` only, while Codex's `CODEX_HOME` is honored. A session started with
+  `CLAUDE_CONFIG_DIR` set therefore installs the binary and then reports no
+  harness found. Engine-side gap, tracked separately from the plugin.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Installs the pinned handrail binary on miss and syncs once after a fresh install.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# handrail bootstrap, run from SessionStart by both plugins.
+#
+# Install-on-miss: a PATH binary (brew, go install) is the user's and is never
+# touched; otherwise the pinned release artifact is downloaded, verified against
+# the release's checksums.txt, and installed under the XDG data dir. Sync runs
+# once, right after a fresh install, so the plugin works with zero manual steps.
+#
+# Invoked as `sh bootstrap.sh` because exec-bit survival through the plugin
+# cache is undocumented upstream (docs/plugin-verification.md).
+
+set -eu
+
+# The version this plugin pins; equal to the plugin's own version, since the
+# manifest version is the cache key that ships a new bootstrap. Bump both.
+PIN=0.1.0-rc.1
+REPO=svyatov/handrail
+
+# A binary the user's package manager owns wins, always.
+if command -v handrail >/dev/null 2>&1; then
+	exit 0
+fi
+
+bindir=${XDG_DATA_HOME:-$HOME/.local/share}/handrail/bin
+bin=$bindir/handrail
+
+if [ -x "$bin" ] && [ "$("$bin" version 2>/dev/null | head -n 1)" = "handrail $PIN" ]; then
+	exit 0
+fi
+
+die() {
+	echo "handrail bootstrap: $1" >&2
+	exit 1
+}
+
+case $(uname -s) in
+Darwin) os=darwin ;;
+Linux) os=linux ;;
+*) die "unsupported operating system $(uname -s)" ;;
+esac
+
+case $(uname -m) in
+x86_64 | amd64) arch=amd64 ;;
+arm64 | aarch64) arch=arm64 ;;
+*) die "unsupported architecture $(uname -m)" ;;
+esac
+
+command -v curl >/dev/null 2>&1 || die "curl is required to install the binary"
+
+digest() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | cut -d' ' -f1
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | cut -d' ' -f1
+	else
+		die "no sha256 tool found (sha256sum or shasum)"
+	fi
+}
+
+archive=handrail_${PIN}_${os}_${arch}.tar.gz
+base=https://github.com/$REPO/releases/download/v$PIN
+
+# Everything lands in a temp dir first, so a failure anywhere above the final
+# rename leaves nothing half-installed. The staging name carries the pid, so two
+# sessions starting at once cannot rename each other's half-written copy.
+staged=$bin.$$
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp" "$staged"' EXIT
+
+# A stalled download must not eat the hook's whole timeout budget.
+curl -fsSL --retry 2 --max-time 45 -o "$tmp/$archive" "$base/$archive" ||
+	die "cannot download $base/$archive"
+curl -fsSL --retry 2 --max-time 45 -o "$tmp/checksums.txt" "$base/checksums.txt" ||
+	die "cannot download $base/checksums.txt"
+
+want=$(awk -v f="$archive" '$2 == f || $2 == "*" f {print $1; exit}' "$tmp/checksums.txt")
+[ -n "$want" ] || die "$archive is not listed in the release's checksums.txt"
+
+got=$(digest "$tmp/$archive")
+[ "$got" = "$want" ] || die "checksum mismatch for $archive: expected $want, got $got"
+
+tar -xzf "$tmp/$archive" -C "$tmp" handrail || die "cannot extract $archive"
+
+mkdir -p "$bindir"
+# Rename within the target directory, so the swap is atomic on any Unix.
+cp "$tmp/handrail" "$staged"
+chmod +x "$staged"
+mv "$staged" "$bin"
+
+echo "handrail $PIN installed at $bin"
+# Sync is the last step and reports its own errors. Failing it would fail the
+# hook, which reads as a broken session start over a binary that installed fine.
+"$bin" sync || echo "handrail: sync failed; run \"$bin\" sync once the cause is fixed" >&2

--- a/skills/add/SKILL.md
+++ b/skills/add/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: add
+description: Turn a plain-language guardrail into a handrail Rule file, validate it, and relay the native permission entry handrail recommends. Use when the user wants to add, write, or create a handrail rule, or says "never let the agent ...", "block ...", "warn me when ..." and wants it enforced from now on.
+---
+
+# Add a handrail Rule
+
+A Rule is one markdown file: a YAML frontmatter Matcher and a prose message. The
+filename is the rule's identity. You write the file, `handrail` validates it.
+
+## 1. Resolve the binary
+
+```sh
+HANDRAIL=$(command -v handrail || echo "${XDG_DATA_HOME:-$HOME/.local/share}/handrail/bin/handrail")
+```
+
+If it does not exist, the SessionStart bootstrap has not run yet: tell the user
+to start a new session, or to install with `brew install svyatov/tap/handrail`.
+Do not hand-write harness config as a workaround.
+
+## 2. Ask for what the description does not settle
+
+Only ask about what you cannot infer. Most descriptions settle everything but
+the tier.
+
+- **What the rule catches**: which event, which tool kind, which field values.
+- **Action**: `block` denies the call with the message as the reason; `warn`
+  lets it proceed and injects the message. Default to `warn` unless the user
+  says never, or the action is destructive.
+- **Tier**: see step 4.
+
+## 3. Write the Matcher
+
+```markdown
+---
+event: PreToolUse
+kind: shell
+action: block
+conditions:
+  - field: command
+    starts_with: git push --force
+---
+Never force-push. Rewrite history locally and open a pull request instead.
+```
+
+**Events**: `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`,
+`SessionEnd`, `Stop`. `event:` is required. `block` is only enforceable on
+`PreToolUse`, `UserPromptSubmit`, and `Stop`; elsewhere it degrades to a warn,
+and `sync` and `doctor` report where. Codex also degrades a `UserPromptSubmit`
+block to a warn.
+
+**Kinds** (optional; omit to match every kind) and the fields each carries:
+
+| `kind` | Fields |
+|---|---|
+| `shell` | `command` |
+| `file_edit` | `path`, `content` |
+| `file_read` | `path` |
+| `mcp` | `server`, `tool` |
+| `other` | none |
+
+`UserPromptSubmit` carries `prompt`. A condition against a field the event does
+not carry never matches, in either polarity, so narrow with `event:` and `kind:`
+rather than relying on a field being absent. Only `PreToolUse` and `PostToolUse`
+carry a kind at all: a `kind:` on any other event never matches.
+
+**Conditions** are ANDed. One entry may be an `any:` group for OR, one level
+deep only:
+
+```yaml
+conditions:
+  - field: path
+    glob: "**/*.env"
+  - any:
+      - field: content
+        contains: SECRET
+      - field: content
+        matches: (?i)api[_-]?key
+```
+
+**Operators**, one per condition, as the key next to `field`: `matches` (RE2),
+`contains`, `equals`, `starts_with`, `ends_with`, `glob`. Prefix any of them
+with `not_` to negate. RE2 has no lookarounds and no backreferences. Everything
+is case-sensitive; regexes opt in with an inline `(?i)`.
+
+**Globs** are `path.Match` plus `**`, anchored to the whole field, so they match
+all of it rather than a substring. `*` and `?` never cross `/`. `**` spans
+directories only as its own segment, leading or after a `/`; anywhere else it
+reads as `*`. `**/` matches zero directories too, so `**/*.env` covers a file at
+the repo root, and a trailing `**` matches every depth below. In `[...]` classes
+a leading `^` negates and `!` is an ordinary member, unlike gitignore; `\` makes
+the next character literal.
+
+**Message**: the markdown body, addressed to the agent, in prose. Say what is
+forbidden and what to do instead. No templating; `{{` stays literal.
+
+**Housekeeping**: `action:` defaults to `warn` and `enabled:` to true. There is
+no `name:` field and no `pattern:` shorthand. When several rules match one
+event, every message is delivered labeled with its rule name, and one `block`
+makes the outcome a block.
+
+## 4. Pick the tier and the path
+
+Filename is the identity: kebab-case, descriptive, `.md`.
+
+| Tier | Path | Use when |
+|---|---|---|
+| Project-personal | `.handrail/local/<name>.md` | Default. Private to this repo and this machine. |
+| Global | `${XDG_CONFIG_HOME:-$HOME/.config}/handrail/<name>.md` | The rule is project-agnostic and should hold in every repo. |
+| Project-shared | `.handrail/<name>.md` | Only when the user explicitly asks to commit it for the team. Never write here otherwise. Inert until `handrail trust` is run for this repo. |
+
+If you just created `.handrail/local/` in this repo, run `"$HANDRAIL" sync`
+once: sync is what appends the ignore line to `.git/info/exclude`, so without it
+private rules show up in `git status`.
+
+A same-named file in a higher tier shadows the lower one wholesale, and a
+duplicate name within one tier is a hard error, so check the `check` output in
+step 5 for the name you chose before settling on it. To disable an inherited
+rule, write the same filename one tier up with only `enabled: false` in the
+frontmatter and nothing else.
+
+## 5. Validate
+
+```sh
+"$HANDRAIL" check
+```
+
+Show the user the new rule's line from the output. Errors name the failing
+file: fix and re-run until clean. A rule is live as soon as it validates; no
+re-sync is needed.
+
+A Project-shared rule in an untrusted repo is valid but absent from the table,
+and `check` says so on stderr. That is not a rule to fix: tell the user to run
+`"$HANDRAIL" trust`.
+
+## 6. Prove it matches
+
+Replay the case that motivated the rule:
+
+```sh
+"$HANDRAIL" test PreToolUse --kind shell --field command='git push --force origin main'
+```
+
+Exit code 2 means blocked, 0 means allowed. If the rule does not appear in the
+matched list, the Matcher is wrong: fix it before moving on. Test a near-miss
+too when the rule could be too broad.
+
+## 7. Relay the Advisor
+
+```sh
+"$HANDRAIL" advise <rule-name> --harness <the harness you are running in> --json
+```
+
+Some block rules translate into a native harness permission entry, which is a
+fail-closed backstop for the hook path. Without `--harness` the output covers
+every harness handrail knows, so scope it: never offer a Codex entry inside a
+Claude Code session. For each entry in the array, show the user its `entry`
+field **verbatim** with its `location`, plus `scope_widening` and `caveats` when
+they are set, and offer to apply it. Apply only on consent.
+
+Never invent or adapt a harness pattern yourself: the translation knowledge
+lives in the binary. An empty array (`[]`) means the rule does not translate
+safely, which is normal and not a failure.


### PR DESCRIPTION
Closes #29.

## What changed

The Claude Code plugin per [ADR 0006](docs/adr/0006-cli-and-plugin-surface.md) and spec section 7: a manifest, `/handrail:add`, and a SessionStart bootstrap.

- `.claude-plugin/plugin.json` and `marketplace.json`. The repo root doubles as the plugin root and its own marketplace, because both plugin manifests have to reference one `skills/` directory and a copied plugin cannot reach outside its own directory. The cost is one `claude plugin validate --strict` warning about the repo's own `CLAUDE.md` at the plugin root, which is expected.
- `hooks/hooks.json`, registered by auto-discovery. It invokes the script as `sh <path>` rather than executing it, because exec-bit survival through the plugin cache is undocumented upstream.
- `scripts/bootstrap.sh`. Install-on-miss: a PATH binary belongs to the user's package manager and is never touched; otherwise the pinned artifact is downloaded, verified against the release's `checksums.txt`, staged under a pid-suffixed name, and renamed into `$XDG_DATA_HOME/handrail/bin/`, so no failure path leaves a half-install. Sync runs once after a fresh install and reports its own errors without failing the hook, since a broken sync should not read as a broken session start.
- `skills/add/SKILL.md`. The plugin ships without the repo's docs, so the skill carries the rule format itself. It holds zero harness pattern knowledge and relays `advise --json` verbatim.
- `docs/plugin-verification.md`. Plugins sit outside the testscript seam ([ADR 0009](docs/adr/0009-testing-strategy.md)), so this checklist is their acceptance gate.

## Verification

Against the real `v0.1.0-rc.1` release, in sandboxed homes:

- Fresh install downloads, verifies, installs, and syncs six hook entries naming the absolute managed path.
- A corrupted archive is refused with both digests named and nothing written.
- A PATH binary is left alone; a managed binary at the wrong version is reinstalled; a matching one is a silent no-op.
- Installed as a real plugin, `hooks/hooks.json` registered by auto-discovery, the hook fired on a headless session, and `bootstrap.sh` kept mode 755 in the plugin cache.

`/handrail:add` was exercised command by command (`check`, `test`, `advise --json`) rather than through a live session, which had no credentials. `shellcheck -s sh` is clean; `task lint` and `task test` pass.

## Noted, not fixed here

`sync` honours `CODEX_HOME` but has no equivalent for `CLAUDE_CONFIG_DIR`, so a session started with that variable set installs the binary and then reports no harness found. Engine-side, recorded in the verification doc.