### PR TITLE
fix(sync): follow CLAUDE_CONFIG_DIR when detecting Claude Code

### DIFF
--- a/docs/plugin-verification.md
+++ b/docs/plugin-verification.md
@@ -8,11 +8,11 @@ or a plugin manifest changes, and record what the run showed.
 ## Checklist
 
 Run each case against an isolated `HOME`, never the real one, so a failed run
-cannot leave hook entries behind on the machine. Create `$HOME/.claude` in it:
-harness detection reads that path and nothing else, so without it sync finds no
-harness and case 1 cannot pass. Isolate the plugin install with
-`CLAUDE_CONFIG_DIR`, which moves where Claude Code itself stores plugins but,
-per the findings below, does not move where sync looks.
+cannot leave hook entries behind on the machine. Isolate the plugin install with
+`CLAUDE_CONFIG_DIR`, which moves where Claude Code stores plugins and where sync
+writes alike. Create that directory, or `$HOME/.claude` when the variable is
+unset: harness detection reads it, so without it sync finds no harness and case
+1 cannot pass.
 
 | # | Case | Expected |
 |---|---|---|
@@ -52,7 +52,8 @@ archive; the others hit the real release.
   one warning from `claude plugin validate --strict`: a `CLAUDE.md` at the plugin
   root is not loaded as plugin context. That file is the repo's own agent
   instructions and is meant to stay; the warning is expected.
-- **`CLAUDE_CONFIG_DIR` is not honored by sync.** Harness detection looks at
-  `~/.claude` only, while Codex's `CODEX_HOME` is honored. A session started with
-  `CLAUDE_CONFIG_DIR` set therefore installs the binary and then reports no
-  harness found. Engine-side gap, tracked separately from the plugin.
+- **`CLAUDE_CONFIG_DIR` was not honored by sync.** Harness detection looked at
+  `~/.claude` only, while Codex's `CODEX_HOME` was honored, so a session started
+  with `CLAUDE_CONFIG_DIR` set installed the binary and then reported no harness
+  found. Fixed in #37: the claude adapter carries the variable the way the codex
+  one does.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,7 +105,7 @@ Hardcoded in Go per Adapter, next to its translation knowledge. Per-event: exist
 | Transcript access | Yes (`transcript_path`, written asynchronously, tail may lag) | Yes (`transcript_path`) |
 | Fail-open on hook error | Yes (documented) | Yes |
 | Tool names on the wire | `Bash`, `Edit`/`Write`, `Read`, `mcp__<server>__<tool>` | The same, plus `apply_patch` for every file edit, whose whole edit rides in `tool_input.command` |
-| Config sync writes | `~/.claude/settings.json` | `~/.codex/hooks.json`, or `$CODEX_HOME/hooks.json` where that is set |
+| Config sync writes | `~/.claude/settings.json`, or `$CLAUDE_CONFIG_DIR/settings.json` where that is set | `~/.codex/hooks.json`, or `$CODEX_HOME/hooks.json` where that is set |
 | Known bypasses | `disableAllHooks`, cloud sessions | an enterprise `allow_managed_hooks_only` requirement. `--dangerously-bypass-hook-trust` skips the trust review rather than the hooks, and `codex exec --ignore-rules` bypasses execpolicy, which costs a promoted rule (section 5) its backstop but leaves the hook path intact |
 
 Codex's hash-based hook trust prompts once per entry change; the stable one-entry-per-event shape (section 3) keeps that to a single approval.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -31,7 +31,7 @@ type Adapter struct {
 // The differences are the file it lives in and where blocking stops.
 var adapters = []Adapter{
 	{
-		Name: "claude", title: "Claude Code", dir: ".claude", file: "settings.json",
+		Name: "claude", title: "Claude Code", dir: ".claude", homeEnv: "CLAUDE_CONFIG_DIR", file: "settings.json",
 		blocksPrompt: true,
 		Quirks: []string{
 			"hook errors and timeouts fail open, so a broken guardrail never stops the session",

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -58,6 +58,30 @@ func TestAdapterWithoutAHomeDirectory(t *testing.T) {
 	}
 }
 
+// Every harness handrail syncs for lets a variable relocate its config
+// directory, and config written anywhere else is config it never reads. The
+// field is opt-in per adapter, so an adapter added without one fails silently:
+// detection and sync go to ~/<dir> while the harness reads elsewhere. Only a
+// walk of the table can catch that, which the compiled binary cannot do.
+func TestEveryAdapterFollowsItsRelocationVariable(t *testing.T) {
+	for _, a := range Adapters() {
+		t.Run(a.Name, func(t *testing.T) {
+			if a.homeEnv == "" {
+				t.Fatalf("%s has no homeEnv, so its relocation variable is ignored", a.Name)
+			}
+			dir := t.TempDir()
+			t.Setenv(a.homeEnv, dir)
+
+			if got, want := a.ConfigPath(), filepath.Join(dir, a.file); got != want {
+				t.Errorf("ConfigPath() = %q, want %q", got, want)
+			}
+			if !a.Installed() {
+				t.Error("Installed() = false for the directory the variable names")
+			}
+		})
+	}
+}
+
 func TestWriteReportsAnUnusableParent(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(file, []byte("{}\n"), 0o600); err != nil {

--- a/testdata/script/sync_claude.txtar
+++ b/testdata/script/sync_claude.txtar
@@ -59,6 +59,18 @@ grep -count=1 'hook claude PreToolUse' home/.claude/settings.json
 exec handrail sync --harness claude
 stdout 'claude: 6 hook entries already current'
 
+# $CLAUDE_CONFIG_DIR moves the config Claude Code reads, so sync and doctor
+# follow it: ~/.claude there is a file the harness never opens, and may not
+# exist at all.
+env CLAUDE_CONFIG_DIR=$WORK/elsewhere/claude
+mkdir $WORK/elsewhere/claude
+exec handrail sync --harness claude
+stdout 'claude: wrote 6 hook entries to .*/elsewhere/claude/settings.json'
+exists elsewhere/claude/settings.json
+exec handrail doctor
+stdout '^ok +claude: config at .*/elsewhere/claude/settings\.json$'
+env CLAUDE_CONFIG_DIR=
+
 -- .git/HEAD --
 ref: refs/heads/main
 -- .git/info/exclude --


### PR DESCRIPTION
Closes #37.

## What changed

Harness detection read `$HOME/.claude` unconditionally, so a Claude Code install relocated by `CLAUDE_CONFIG_DIR` was invisible to `sync` and to `doctor`. Both now follow the variable, the way they already follow `CODEX_HOME`.

- `internal/harness/harness.go`: the claude adapter carries `homeEnv: "CLAUDE_CONFIG_DIR"`. `userDir()` already handles relocation for any adapter that names a variable, and `CLAUDE_CONFIG_DIR` names the config directory itself, exactly like `CODEX_HOME`, so no suffix is appended and no other code changed.
- `testdata/script/sync_claude.txtar`: the regression case, at the same seam as the existing `CODEX_HOME` one. It asserts that `sync` writes to the relocated directory and that `doctor` reports on it.
- `internal/harness/harness_test.go`: `homeEnv` is opt-in per adapter, so an adapter added without one fails in silence. A unit test walks the adapter table and asserts that every adapter follows its own variable. Enumerating the table is what the compiled binary cannot reach ([ADR 0009](docs/adr/0009-testing-strategy.md)).
- `docs/spec.md`: section 4's "Config sync writes" row now reads the way the Codex column already does.
- `docs/plugin-verification.md`: the recorded finding is marked fixed, and the checklist's isolation note is corrected, because setting the variable now moves sync too.

## Verification

The testscript case was confirmed red before the fix: `sync` reported `6 hook entries already current in $WORK/home/.claude/settings.json` while `CLAUDE_CONFIG_DIR` pointed elsewhere. The unit test was confirmed red the same way, with `homeEnv` removed from the claude adapter.

`task test`, `task lint`, and `task cover` (97.6%) pass.