### PR TITLE
feat(plugin): Codex plugin parity through the repo's own marketplace (#30)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "handrail",
+  "description": "Declare an agent guardrail once, in one neutral format, and enforce it through every harness's native hooks.",
+  "version": "0.1.0-rc.1",
+  "author": {
+    "name": "Leonid Svyatov",
+    "email": "leonid@svyatov.com"
+  },
+  "homepage": "https://github.com/svyatov/handrail",
+  "repository": "https://github.com/svyatov/handrail",
+  "license": "MIT",
+  "keywords": ["guardrails", "hooks", "safety", "rules"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,7 +57,9 @@ tasks:
       # carries it as its cache key, so all three move together or the plugin
       # ships a bootstrap that installs the wrong binary.
       - >-
-        ruby -rjson -e 'pin = File.read("scripts/bootstrap.sh")[/^PIN=(.+)$/, 1];
-        %w[.claude-plugin .codex-plugin].each { |dir|
-        version = JSON.parse(File.read("#{dir}/plugin.json"))["version"];
-        abort "#{dir}/plugin.json is #{version}, bootstrap pins #{pin}" unless version == pin }'
+        pin=$(sed -n 's/^PIN=//p' scripts/bootstrap.sh);
+        for dir in .claude-plugin .codex-plugin; do
+        version=$(sed -n 's/^ *"version": "\(.*\)",*$/\1/p' "$dir/plugin.json");
+        [ "$version" = "$pin" ] ||
+        { echo "$dir/plugin.json is $version, bootstrap pins $pin" >&2; exit 1; };
+        done

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,14 @@ tasks:
       - golangci-lint fmt --diff
 
   release-check:
-    desc: Validate .goreleaser.yml, so a bad config fails here rather than on a tag
+    desc: Validate .goreleaser.yml and the pinned version, so a bad config fails here rather than on a tag
     cmds:
       - goreleaser check
+      # The bootstrap pins the version it installs and each plugin manifest
+      # carries it as its cache key, so all three move together or the plugin
+      # ships a bootstrap that installs the wrong binary.
+      - >-
+        ruby -rjson -e 'pin = File.read("scripts/bootstrap.sh")[/^PIN=(.+)$/, 1];
+        %w[.claude-plugin .codex-plugin].each { |dir|
+        version = JSON.parse(File.read("#{dir}/plugin.json"))["version"];
+        abort "#{dir}/plugin.json is #{version}, bootstrap pins #{pin}" unless version == pin }'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,13 +53,4 @@ tasks:
     desc: Validate .goreleaser.yml and the pinned version, so a bad config fails here rather than on a tag
     cmds:
       - goreleaser check
-      # The bootstrap pins the version it installs and each plugin manifest
-      # carries it as its cache key, so all three move together or the plugin
-      # ships a bootstrap that installs the wrong binary.
-      - >-
-        pin=$(sed -n 's/^PIN=//p' scripts/bootstrap.sh);
-        for dir in .claude-plugin .codex-plugin; do
-        version=$(sed -n 's/^ *"version": "\(.*\)",*$/\1/p' "$dir/plugin.json");
-        [ "$version" = "$pin" ] ||
-        { echo "$dir/plugin.json is $version, bootstrap pins $pin" >&2; exit 1; };
-        done
+      - scripts/check-version-pin.sh

--- a/docs/plugin-verification.md
+++ b/docs/plugin-verification.md
@@ -9,10 +9,21 @@ or a plugin manifest changes, and record what the run showed.
 
 Run each case against an isolated `HOME`, never the real one, so a failed run
 cannot leave hook entries behind on the machine. Isolate the plugin install with
-`CLAUDE_CONFIG_DIR`, which moves where Claude Code stores plugins and where sync
-writes alike. Create that directory, or `$HOME/.claude` when the variable is
-unset: harness detection reads it, so without it sync finds no harness and case
-1 cannot pass.
+`CLAUDE_CONFIG_DIR` on Claude Code and `CODEX_HOME` on Codex, which move where
+the harness stores plugins and where sync writes alike. Create that directory,
+or `$HOME/.claude` and `$HOME/.codex` when the variable is unset: harness
+detection reads it, so without it sync finds no harness and case 1 cannot pass.
+
+Run the whole checklist once per harness. Installing the plugin is:
+
+```sh
+codex plugin marketplace add <repo path or git URL>
+codex plugin add handrail@handrail
+```
+
+Codex holds every non-managed hook until it is trusted, so on Codex every case
+that runs through a session needs that trust granted first; see the Codex
+findings below.
 
 | # | Case | Expected |
 |---|---|---|
@@ -24,7 +35,7 @@ unset: harness detection reads it, so without it sync finds no harness and case
 | 6 | Plugin installed from a marketplace | `scripts/bootstrap.sh` survives the copy into the plugin cache and the SessionStart hook fires |
 | 7 | `/handrail:add` from a plain-language description | A rule file that `check` accepts, `test` matches against its own incident, and `advise` reports on |
 
-## 2026-08-18, v0.1.0-rc.1 on darwin/arm64
+## 2026-08-18, v0.1.0-rc.1 on Claude Code, darwin/arm64
 
 Cases 1 to 6 pass. Case 2 was driven with a stub `curl` serving a corrupted
 archive; the others hit the real release.
@@ -57,3 +68,63 @@ archive; the others hit the real release.
   with `CLAUDE_CONFIG_DIR` set installed the binary and then reported no harness
   found. Fixed in #37: the claude adapter carries the variable the way the codex
   one does.
+
+## 2026-08-18, v0.1.0-rc.1 on Codex CLI 0.147.0, darwin/arm64
+
+Cases 1 to 6 pass, each driven through a headless `codex exec` session against
+an isolated `CODEX_HOME` and `HOME`, so the bootstrap ran as a real Codex hook
+rather than as a script. Case 2 used a stub `curl` serving a corrupted archive;
+the others hit the real release.
+
+- The repo installs as a marketplace and a plugin: `codex plugin marketplace add
+  <repo>` then `codex plugin add handrail@handrail` reported version
+  `0.1.0-rc.1` and copied the plugin into `$CODEX_HOME/plugins/cache/`.
+  `scripts/bootstrap.sh` survived the copy at mode `755`.
+- Case 1 and case 6 are one run here: the SessionStart hook fired, installed
+  `handrail_0.1.0-rc.1_darwin_arm64.tar.gz` at mode `755` under the sandbox
+  `HOME`, and synced six entries into the sandbox `$CODEX_HOME/hooks.json`, each
+  naming that absolute path.
+- Case 2 refused the install naming both digests, and left no `bin` directory.
+  Case 3 wrote nothing when a `handrail` sat on the session's `PATH`. Case 4
+  replaced a stub reporting `handrail 0.0.1` with the pinned binary. Case 5 left
+  the installed binary byte-identical.
+- The add skill loads: a headless session listed it by name and read back its
+  description verbatim, so one `skills/` directory serves both harnesses. Case 7
+  was exercised command by command, as on Claude Code, because the sandboxed
+  session had no credentials.
+
+### Findings
+
+- **Codex reads the Claude manifests when its own are absent.** Manifest lookup
+  is `.codex-plugin/plugin.json`, then `.claude-plugin/plugin.json`, then
+  `.cursor-plugin/plugin.json`; marketplace lookup is
+  `.agents/plugins/marketplace.json`, then `.agents/plugins/api_marketplace.json`,
+  then `.claude-plugin/marketplace.json`, then `.cursor-plugin/marketplace.json`.
+  So the repo carries one marketplace file, the Claude-shaped one, which Codex
+  accepts as written, and a `.codex-plugin/plugin.json` because the spec names it
+  and because it is the manifest Codex prefers. Its `skills` and `hooks` paths
+  are supplemented on top of Codex's own component discovery rather than
+  replacing it, and naming a path Codex would have discovered anyway registers it
+  once, not twice: an instrumented copy of the bootstrap recorded exactly one run
+  per session.
+- **The hook trust review is the expected first-run friction, twice over.** Codex
+  holds every non-managed hook, plugin hooks included, until the user trusts it
+  in the TUI's hooks screen; the trust state is a `[hooks.state]` entry keyed by
+  config path, event, and index in `$CODEX_HOME/config.toml`. Until then the hook
+  is skipped, and `codex exec` skips it silently: a headless run installed
+  nothing and printed nothing. So a new user meets the review once for the
+  plugin's bootstrap hook, and again for the entries `sync` then writes into
+  `$CODEX_HOME/hooks.json`, before any guardrail fires. Each entry is reviewed
+  once and re-reviewed only when it changes, which is what the stable
+  one-entry-per-event shape buys ([spec](spec.md) section 3). The runs above were
+  driven with `--dangerously-bypass-hook-trust` per invocation, against the
+  sandbox home; that flag is for vetted automation, not for users.
+- **A failing bootstrap is silent inside `codex exec`.** Case 2's refusal message
+  never reached the session output, and the mismatch had to be read by running
+  the script directly. The failure mode is safe (nothing installs) but
+  undiagnosable from the session, so `handrail doctor` stays the first command
+  when nothing fires.
+- **Plugin hook env**: Codex's hook runner carries `PLUGIN_ROOT` and
+  `CLAUDE_PLUGIN_ROOT` alike, so `hooks/hooks.json` invokes the bootstrap through
+  `${CLAUDE_PLUGIN_ROOT}` on both harnesses, unchanged. The case 1 run resolved
+  it and installed the binary, which is the proof.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,7 +12,8 @@
 set -eu
 
 # The version this plugin pins; equal to the plugin's own version, since the
-# manifest version is the cache key that ships a new bootstrap. Bump both.
+# manifest version is the cache key that ships a new bootstrap. Bump this and
+# the version in both manifests, .claude-plugin/ and .codex-plugin/, together.
 PIN=0.1.0-rc.1
 REPO=svyatov/handrail
 

--- a/scripts/check-version-pin.sh
+++ b/scripts/check-version-pin.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# The bootstrap pins the version it installs, and each plugin manifest carries
+# that version as its cache key: the manifest version is what ships a new
+# bootstrap. All three move together, or a plugin installs the wrong binary.
+#
+# Run from the repo root, by `task release-check`.
+
+set -eu
+
+pin=$(sed -n 's/^PIN=//p' scripts/bootstrap.sh)
+[ -n "$pin" ] || {
+	echo "scripts/bootstrap.sh has no PIN line" >&2
+	exit 1
+}
+
+status=0
+for dir in .claude-plugin .codex-plugin; do
+	version=$(sed -n 's/^ *"version": "\(.*\)",*$/\1/p' "$dir/plugin.json")
+	# Every manifest is reported, so one run names every file to bump.
+	[ "$version" = "$pin" ] || {
+		echo "$dir/plugin.json is $version, bootstrap pins $pin" >&2
+		status=1
+	}
+done
+
+exit $status


### PR DESCRIPTION
Closes #30.

## What changed

- `.codex-plugin/plugin.json`, the manifest Codex prefers, pointing at the `skills/` and `hooks/hooks.json` the Claude Code plugin already uses.
- No second marketplace file: Codex's marketplace lookup falls through to `.claude-plugin/marketplace.json` and accepts it as written, so `codex plugin marketplace add <repo>` then `codex plugin add handrail@handrail` installs from the repo itself.
- No bootstrap change: Codex's hook runner carries `CLAUDE_PLUGIN_ROOT` alongside its own `PLUGIN_ROOT`, so one hook entry resolves on either harness.
- `scripts/check-version-pin.sh`, run by `task release-check`, asserting the bootstrap `PIN` equals both manifest versions.
- The Codex run record and findings in `docs/plugin-verification.md`.

## Why this shape

The spec names `.codex-plugin/plugin.json` and the manifest is what Codex reads first, so parity costs one file rather than a parallel plugin tree. Naming `skills` and `hooks` paths there duplicates what Codex would discover anyway, and an instrumented bootstrap confirmed that registers the hook once, not twice.

The version now lives in three files. The comment saying to bump them together is not a guard, so `release-check` asserts it and names every manifest that drifted.

## Verification

Cases 1 to 6 of `docs/plugin-verification.md` were re-run on Codex CLI 0.147.0, darwin/arm64, each through a real `codex exec` hook against an isolated `CODEX_HOME` and `HOME`: fresh install with sha256 verification and auto-sync, corrupted archive refused with both digests, `PATH` binary respected, stale version reinstalled, pinned version untouched, marketplace install with the exec bit surviving. The add skill loads and reads back its description verbatim. Trusted hooks were bypassed per invocation against the sandbox home only.

Two first-run facts came out of it, both documented rather than fixed: the trust review is met twice, once for the plugin's bootstrap hook and again for the entries `sync` writes, and a refused install prints nothing inside `codex exec`, which leaves `handrail doctor` as the diagnosis path.

The analyze skill is #31 and is not in scope here.