### PR TITLE
docs(context): define Effective ruleset

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,10 @@ _Avoid_: scope, level
 **Shadowing**:
 A rule file in a higher-precedence tier replacing a same-named rule in a lower tier wholesale. There is no field-level merging; the shadowing file is the effective rule.
 
+**Effective ruleset**:
+The merged, shadow-resolved set of rules for one working directory: every tier that applies, with each shadowed rule replaced by its higher-tier namesake. What `check` prints and what the Analyzer reads.
+_Avoid_: conflating with the rules that match one event, which is a matcher outcome rather than a set
+
 **Matcher**:
 The selecting half of a rule: an event name, an optional tool kind, and a list of conditions.
 


### PR DESCRIPTION
## What changed

Adds **Effective ruleset** to the glossary, immediately after **Shadowing**, because it is what shadowing resolves into.

## Why

The term already carries weight across the repository: it appears eleven times in the spec, in ADRs 0004, 0006, and 0007, in the analyze skill, and in the CLI, always meaning the same thing. It had no entry, so nothing pinned that meaning down.

It also needed one boundary drawn. "Effective" was doing two jobs: the merged, shadow-resolved set of rules for a working directory, and the rules a single event happens to match. The second is a matcher outcome rather than a set, so the entry claims the term for the first and warns off the second.

No behaviour changes. Documentation only.