### PR TITLE
refactor(rule): point a shadowed rule at the rule that shadows it (#42)

### DIFF
--- a/internal/harness/sync.go
+++ b/internal/harness/sync.go
@@ -271,7 +271,7 @@ func (d Degradation) String() string {
 func (a Adapter) Degradations(rules []*rule.Rule) []Degradation {
 	var out []Degradation
 	for _, r := range rules {
-		if !r.Enabled || r.ShadowedBy != "" {
+		if !r.Enabled || r.ShadowedBy != nil {
 			continue
 		}
 		if r.Action == "block" && !a.canBlock(r.Event) {

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -33,7 +33,7 @@ type Discovery struct {
 // LoadTiers parses every tier that applies to cwd: Global from the XDG config
 // dir, Project-shared at the project root, Project-personal under it. Rules
 // come back in delivery order, tier by tier and alphabetical within a tier,
-// each tagged with its tier and with the higher-tier file that shadows it.
+// each tagged with its tier and with the higher-tier rule that shadows it.
 func LoadTiers(cwd string) ([]*Rule, []Problem, Discovery) {
 	root := RepoRoot(cwd)
 	d := Discovery{Root: root}
@@ -76,7 +76,7 @@ func LoadTiers(cwd string) ([]*Rule, []Problem, Discovery) {
 	}
 	for _, r := range rules {
 		if effective := byName[r.Name]; effective != r {
-			r.ShadowedBy = effective.Path
+			r.ShadowedBy = effective
 		}
 	}
 	return rules, problems, d

--- a/internal/rule/match.go
+++ b/internal/rule/match.go
@@ -19,7 +19,7 @@ type Payload struct {
 func Effective(rules []*Rule, p Payload) []*Rule {
 	var out []*Rule
 	for _, r := range rules {
-		if r.ShadowedBy == "" && r.Matches(p) {
+		if r.ShadowedBy == nil && r.Matches(p) {
 			out = append(out, r)
 		}
 	}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -14,7 +14,7 @@ type Rule struct {
 	Name       string
 	Path       string
 	Tier       string
-	ShadowedBy string // path of the higher-tier file replacing this one, if any
+	ShadowedBy *Rule // the higher-tier rule replacing this one, if any
 	Event      string
 	Kind       string
 	Action     string

--- a/main.go
+++ b/main.go
@@ -364,7 +364,7 @@ func cmdAdvise(args []string, stdout, stderr io.Writer) int {
 	for _, r := range rules {
 		// Advice is about what is live: a shadowed or disabled rule enforces
 		// nothing, so promoting it would install a deny nothing asked for.
-		if !r.Enabled || r.ShadowedBy != "" || (name != "" && r.Name != name) {
+		if !r.Enabled || r.ShadowedBy != nil || (name != "" && r.Name != name) {
 			continue
 		}
 		targets = append(targets, r)
@@ -761,8 +761,8 @@ func cmdCheck(args []string, stdout, stderr io.Writer) int {
 		}
 		for _, r := range rules {
 			var shadowedBy *string
-			if r.ShadowedBy != "" {
-				shadowedBy = &r.ShadowedBy
+			if r.ShadowedBy != nil {
+				shadowedBy = &r.ShadowedBy.Path
 			}
 			out.Rules = append(out.Rules, checkRule{
 				Rule:       r.Name,
@@ -939,19 +939,13 @@ func printRuleset(w io.Writer, rules []*rule.Rule) error {
 	if len(rules) == 0 {
 		return nil
 	}
-	// Rules arrive in tier order, so the last one under a name is the effective
-	// one: the tier that shadows every earlier namesake.
-	effective := make(map[string]string, len(rules))
-	for _, r := range rules {
-		effective[r.Name] = r.Tier
-	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "TIER\tRULE\tEVENT\tKIND\tACTION\tSTATUS")
 	for _, r := range rules {
 		status := "enabled"
 		switch {
-		case r.ShadowedBy != "":
-			status = "shadowed by " + effective[r.Name]
+		case r.ShadowedBy != nil:
+			status = "shadowed by " + r.ShadowedBy.Tier
 		case !r.Enabled:
 			status = "disabled"
 		}


### PR DESCRIPTION
Closes #42.

## What changed

`rule.Rule.ShadowedBy` held the shadowing file's path: a string that named the
fact of shadowing without naming what did the shadowing. So `printRuleset` had
to rebuild a name-to-tier map of its own to report the tier, deriving a second
time what `LoadTiers` already knew.

The field now holds the shadowing `*Rule`. `check` reads the tier off it, and
the map is gone. Four other readers move from `!= ""` to `!= nil`.

## Why

A prefactor with one representation of shadowing in it, so the next change to
this area edits one place instead of two.

## Output is unchanged

`byName` in `LoadTiers` selects the same effective rule the deleted map did, so
both surfaces print the same bytes as before:

- the table's `shadowed by <tier>` comes from `r.ShadowedBy.Tier`
- `--json` `shadowed_by` comes from `r.ShadowedBy.Path`, the string the field
  used to hold directly

`testdata/script/tiers.txtar` pins the three-tier chain, the case where a
last-wins map and a per-rule pointer could diverge, for both surfaces.

## Verification

`task test`, `task lint` (0 issues), and `task cover` (97.6%) pass locally.