### PR TITLE
refactor(rule): trust and the exclude line move behind the ruleset (#45)

### DIFF
--- a/internal/rule/exclude.go
+++ b/internal/rule/exclude.go
@@ -38,22 +38,22 @@ func hasExcludeLine(data []byte) bool {
 	return false
 }
 
-// LocalExcluded reports whether root's exclude file holds the line, and names
-// the file it read. An empty path means root is not a git working tree, where
-// there is nothing to exclude and therefore nothing missing.
-func LocalExcluded(root string) (excluded bool, path string, err error) {
-	path, data, err := readExclude(root)
+// LocalExcluded reports whether this project's exclude file holds the line, and
+// names the file it read. An empty path means the project root is not a git
+// working tree, where there is nothing to exclude and therefore nothing missing.
+func (rs *Ruleset) LocalExcluded() (excluded bool, path string, err error) {
+	path, data, err := readExclude(rs.Root)
 	if err != nil || path == "" {
 		return false, "", err
 	}
 	return hasExcludeLine(data), path, nil
 }
 
-// ExcludeLocal adds the Project-personal tier to root's own exclude file,
-// reporting whether that was new. info/exclude rather than .gitignore: the tier
-// is one user's, and the ignore rule for it is nobody else's business.
-func ExcludeLocal(root string) (added bool, err error) {
-	path, data, err := readExclude(root)
+// ExcludeLocal adds the Project-personal tier to this project's own exclude
+// file, reporting whether that was new. info/exclude rather than .gitignore: the
+// tier is one user's, and the ignore rule for it is nobody else's business.
+func (rs *Ruleset) ExcludeLocal() (added bool, err error) {
+	path, data, err := readExclude(rs.Root)
 	if err != nil || path == "" || hasExcludeLine(data) {
 		return false, err
 	}

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -74,11 +74,11 @@ func Load(cwd string) *Ruleset {
 		rs.Tiers = append(rs.Tiers, t)
 	}
 
-	gather(Tier{Name: TierGlobal, Dir: ConfigDir(), Trusted: true}, false)
+	gather(Tier{Name: TierGlobal, Dir: configDir(), Trusted: true}, false)
 	// A user-level hook entry means any repo on the machine is enforced, so a
 	// clone's committed rules wait for an explicit grant. The user's own two
 	// tiers are never gated.
-	gather(Tier{Name: TierProjectShared, Dir: SharedDir(root), Trusted: IsTrusted(root)}, true)
+	gather(Tier{Name: TierProjectShared, Dir: sharedDir(root), Trusted: isTrusted(root)}, true)
 	gather(Tier{Name: TierProjectPersonal, Dir: LocalDir(root), Trusted: true}, false)
 
 	// Identity is the basename, so the highest tier holding a name carries the
@@ -95,17 +95,18 @@ func Load(cwd string) *Ruleset {
 	return rs
 }
 
-// SharedDir is the Project-shared tier's directory, at the project root.
-func SharedDir(root string) string { return filepath.Join(root, ".handrail") }
+// sharedDir is the Project-shared tier's directory, at the project root.
+func sharedDir(root string) string { return filepath.Join(root, ".handrail") }
 
 // LocalDir is the Project-personal tier's directory, inside the shared one so a
-// single exclude line keeps it out of version control.
-func LocalDir(root string) string { return filepath.Join(SharedDir(root), "local") }
+// single exclude line keeps it out of version control. Exported for import,
+// which writes into the tier without loading it.
+func LocalDir(root string) string { return filepath.Join(sharedDir(root), "local") }
 
-// ConfigDir is the Global tier's directory: XDG on every Unix platform,
+// configDir is the Global tier's directory: XDG on every Unix platform,
 // including macOS, following the git and gh dotfiles precedent rather than
 // os.UserConfigDir's ~/Library/Application Support.
-func ConfigDir() string {
+func configDir() string {
 	return xdgSubdir("XDG_CONFIG_HOME", ".config")
 }
 

--- a/internal/rule/trust.go
+++ b/internal/rule/trust.go
@@ -21,9 +21,9 @@ func trustFile() string {
 	return filepath.Join(dir, "trusted")
 }
 
-// IsTrusted reports whether root's Project-shared tier has been granted. An
+// isTrusted reports whether root's Project-shared tier has been granted. An
 // unreadable registry means untrusted: the gate fails closed.
-func IsTrusted(root string) bool {
+func isTrusted(root string) bool {
 	file := trustFile()
 	if file == "" {
 		return false
@@ -35,14 +35,16 @@ func IsTrusted(root string) bool {
 	return slices.Contains(strings.Split(string(data), "\n"), root)
 }
 
-// Trust records root as trusted, reporting whether that was new.
-func Trust(root string) (added bool, err error) {
+// Trust records this ruleset's project root as trusted, reporting whether that
+// was new. The load already knows the root, so a caller holding a ruleset never
+// has to work out which path the grant is keyed by.
+func (rs *Ruleset) Trust() (added bool, err error) {
 	// One path per line, so a newline in a path would write a second line and
 	// grant a path nobody asked for. A directory may legally hold one.
-	if strings.Contains(root, "\n") {
-		return false, fmt.Errorf("cannot trust a path containing a newline: %q", root)
+	if strings.Contains(rs.Root, "\n") {
+		return false, fmt.Errorf("cannot trust a path containing a newline: %q", rs.Root)
 	}
-	if IsTrusted(root) {
+	if isTrusted(rs.Root) {
 		return false, nil
 	}
 	file := trustFile()
@@ -56,7 +58,7 @@ func Trust(root string) (added bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	if _, err := fmt.Fprintln(f, root); err != nil {
+	if _, err := fmt.Fprintln(f, rs.Root); err != nil {
 		_ = f.Close()
 		return false, err
 	}

--- a/internal/rule/trust_test.go
+++ b/internal/rule/trust_test.go
@@ -1,8 +1,4 @@
-// Black box: the trust registry's whole surface is exported, and the CLI covers
-// the rest of it end to end (ADR 0009). What is left is the one path no shell
-// can hand the binary, because an argument cannot carry a newline through argv
-// on every platform the tests run on.
-package rule_test
+package rule
 
 import (
 	"errors"
@@ -11,10 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/svyatov/handrail/internal/rule"
 )
 
+// White box: the CLI covers the trust registry end to end (ADR 0009), and what
+// is left is the one path no shell can hand the binary, because an argument
+// cannot carry a newline through argv on every platform the tests run on. A
+// ruleset built here is the only way to put such a root in front of Trust.
 func TestTrustRefusesAPathThatWouldWriteTwoLines(t *testing.T) {
 	state := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", state)
@@ -22,8 +20,8 @@ func TestTrustRefusesAPathThatWouldWriteTwoLines(t *testing.T) {
 
 	// A directory may legally hold a newline, and the registry is one path per
 	// line: granting this one would grant "/tmp/evil" as well.
-	const root = "/tmp/a\n/tmp/evil"
-	added, err := rule.Trust(root)
+	rs := &Ruleset{Root: "/tmp/a\n/tmp/evil"}
+	added, err := rs.Trust()
 	if err == nil {
 		t.Fatal("Trust() accepted a path containing a newline")
 	}
@@ -33,7 +31,7 @@ func TestTrustRefusesAPathThatWouldWriteTwoLines(t *testing.T) {
 	if !strings.Contains(err.Error(), "newline") {
 		t.Errorf("error = %v, want it to name the newline", err)
 	}
-	if rule.IsTrusted("/tmp/evil") {
+	if isTrusted("/tmp/evil") {
 		t.Error("the second line was granted")
 	}
 	// A refusal writes nothing at all, so there is no registry to inspect.

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func cmdDoctor(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout)
 	r.ok("project root %s", rs.Root)
 	r.checkTiers(rs)
-	r.checkExclusion(rs.Root)
+	r.checkExclusion(rs)
 
 	for _, p := range rs.Problems {
 		r.bad("%s: %s", p.Path, p.Message)
@@ -239,12 +239,12 @@ func (r *report) checkTiers(rs *rule.Ruleset) {
 // checkExclusion reports the line sync writes to keep the Project-personal tier
 // out of version control. Outside a working tree there is nothing to exclude,
 // which is not the same as an exclusion that went missing.
-func (r *report) checkExclusion(root string) {
-	switch excluded, path, err := rule.LocalExcluded(root); {
+func (r *report) checkExclusion(rs *rule.Ruleset) {
+	switch excluded, path, err := rs.LocalExcluded(); {
 	case err != nil:
-		r.bad("cannot read the exclude file of %s: %v", root, err)
+		r.bad("cannot read the exclude file of %s: %v", rs.Root, err)
 	case path == "":
-		r.ok("%s is not a git working tree, so nothing needs excluding", root)
+		r.ok("%s is not a git working tree, so nothing needs excluding", rs.Root)
 	case excluded:
 		r.ok(".handrail/local/ is excluded in .git/info/exclude")
 	default:
@@ -281,16 +281,16 @@ func cmdTrust(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "handrail: %v\n", err)
 		return 1
 	}
-	root := rule.RepoRoot(cwd)
-	added, err := rule.Trust(root)
+	rs := rule.Load(cwd)
+	added, err := rs.Trust()
 	if err != nil {
 		fmt.Fprintf(stderr, "handrail: %v\n", err)
 		return 1
 	}
 	if added {
-		fmt.Fprintf(stdout, "trusted %s\n", root)
+		fmt.Fprintf(stdout, "trusted %s\n", rs.Root)
 	} else {
-		fmt.Fprintf(stdout, "already trusted %s\n", root)
+		fmt.Fprintf(stdout, "already trusted %s\n", rs.Root)
 	}
 	return 0
 }
@@ -556,7 +556,7 @@ func cmdSync(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	added, err := rule.ExcludeLocal(rs.Root)
+	added, err := rs.ExcludeLocal()
 	if err != nil {
 		fmt.Fprintf(stderr, "handrail: %v\n", err)
 		return 1


### PR DESCRIPTION
Closes #45.

## What changed

Granting trust, writing the git exclude line, and asking whether that line is present were free functions the CLI called with a project root it looked up itself. That was the last reason the CLI knew how tier discovery works. They are now methods on the loaded ruleset:

```go
func (rs *Ruleset) Trust() (added bool, err error)
func (rs *Ruleset) ExcludeLocal() (added bool, err error)
func (rs *Ruleset) LocalExcluded() (bool, string, error)
```

`trust` and `sync` go through those, and neither looks up the project root any more. `doctor`'s exclusion check takes the ruleset for the same reason.

With no caller outside the package left, three discovery entry points are unexported: `ConfigDir`, `SharedDir`, and `IsTrusted`. `RepoRoot` and `LocalDir` stay exported, because `import` writes into the Project-personal tier without loading it, and the doc comment on `LocalDir` now says so.

## Why

A caller holding a ruleset should have the only handle it needs. Every place that used to pair a root lookup with a call taking that root is now one call on the thing the load already produced.

## Tests

The newline-in-a-path guard cannot be reached from the command line, because argv cannot carry a newline. Its test moves inside the package and builds the ruleset it needs, rather than faking the situation from outside. It still asserts the same two things: the refusal names the newline, and the second line is not granted.

No testdata changed, so every testscript case passes with byte-identical output. `task test`, `task lint`, and `task cover` (97.9%) pass locally.