### PR TITLE
refactor(rule): one liveness predicate and an Effective selector (#51)

### DIFF
--- a/internal/harness/sync.go
+++ b/internal/harness/sync.go
@@ -266,14 +266,12 @@ func (d Degradation) String() string {
 	return fmt.Sprintf("%s degraded to %s for %s: %s", d.From, d.To, d.Rule, d.Reason)
 }
 
-// Degradations reports where the harness weakens a rule's action. Sync and
-// doctor print this; the runtime hot path stays quiet about it.
+// Degradations reports where the harness weakens a rule's action, for the
+// rules it is given: pass the Effective ruleset, since a rule that cannot fire
+// cannot be degraded. Sync and doctor print this; the hot path stays quiet.
 func (a Adapter) Degradations(rules []*rule.Rule) []Degradation {
 	var out []Degradation
 	for _, r := range rules {
-		if !r.Enabled || r.ShadowedBy != nil {
-			continue
-		}
 		if r.Action == "block" && !a.canBlock(r.Event) {
 			out = append(out, Degradation{
 				Rule: r.Name, From: "block", To: "warn", Reason: a.blockReason(r.Event),

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -46,6 +46,19 @@ type Ruleset struct {
 	Problems []Problem
 }
 
+// Effective returns the Effective ruleset: the rules that can fire, in
+// delivery order. Callers that ask what is enforced want this; Rules is the
+// full set, shadowed and disabled included, for reporting on the load itself.
+func (rs *Ruleset) Effective() []*Rule {
+	var out []*Rule
+	for _, r := range rs.Rules {
+		if r.Live() {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // Load parses every tier that applies to cwd: Global from the XDG config dir,
 // Project-shared at the project root, Project-personal under it. Rules come
 // back in delivery order, tier by tier and alphabetical within a tier, each

--- a/internal/rule/match.go
+++ b/internal/rule/match.go
@@ -12,24 +12,24 @@ type Payload struct {
 	Fields map[string]string
 }
 
-// Match returns the rules that select the payload, in delivery order: tier
-// order, then alphabetical within a tier. A shadowed rule is left out whatever
-// its own matcher says, because the effective rule under that name is its
-// namesake in the higher tier.
+// Match returns the rules of the Effective ruleset that select the payload, in
+// delivery order: tier order, then alphabetical within a tier. Liveness is
+// checked inline rather than over rs.Effective(), because this is the hot path
+// and the selector would allocate a second slice per event.
 func (rs *Ruleset) Match(p Payload) []*Rule {
 	var out []*Rule
 	for _, r := range rs.Rules {
-		if r.ShadowedBy == nil && r.Matches(p) {
+		if r.Live() && r.Matches(p) {
 			out = append(out, r)
 		}
 	}
 	return out
 }
 
-// Matches reports whether this rule's matcher selects the payload. A disabled
-// rule never matches: it exists to shadow a lower tier, not to fire.
+// Matches reports whether this rule's matcher selects the payload. Whether the
+// rule can fire at all is Live's question, not this one's.
 func (r *Rule) Matches(p Payload) bool {
-	if !r.Enabled || r.Event != p.Event {
+	if r.Event != p.Event {
 		return false
 	}
 	if r.Kind != "" && r.Kind != p.Kind {

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -23,6 +23,13 @@ type Rule struct {
 	Message    string
 }
 
+// Live reports whether this rule can fire: enabled, and not shadowed by a
+// higher tier. A rule that is loaded is not thereby a rule that enforces
+// anything, and every caller asking which is which asks here. check reads the
+// two fields directly, because it reports the distinction rather than acts on
+// it.
+func (r *Rule) Live() bool { return r.Enabled && r.ShadowedBy == nil }
+
 // Condition is one entry of a rule's implicit-AND condition list: either a
 // single Term, or a one-level any group that ORs its Terms.
 type Condition struct {

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func cmdDoctor(args []string, stdout, stderr io.Writer) int {
 		r.checkEntries(a, bin)
 		// Degradation is reported at sync time and reprintable here: a rule
 		// weakened months ago is exactly the kind that reads as not firing.
-		for _, deg := range a.Degradations(rs.Rules) {
+		for _, deg := range a.Degradations(rs.Effective()) {
 			r.note("%s: %s", a.Name, deg)
 		}
 		for _, q := range a.Quirks {
@@ -343,11 +343,11 @@ func cmdAdvise(args []string, stdout, stderr io.Writer) int {
 		return code
 	}
 
+	// Advice is about what is live: a shadowed or disabled rule enforces
+	// nothing, so promoting it would install a deny nothing asked for.
 	var targets []*rule.Rule
-	for _, r := range rs.Rules {
-		// Advice is about what is live: a shadowed or disabled rule enforces
-		// nothing, so promoting it would install a deny nothing asked for.
-		if !r.Enabled || r.ShadowedBy != nil || (name != "" && r.Name != name) {
+	for _, r := range rs.Effective() {
+		if name != "" && r.Name != name {
 			continue
 		}
 		targets = append(targets, r)
@@ -548,7 +548,7 @@ func cmdSync(args []string, stdout, stderr io.Writer) int {
 		} else {
 			fmt.Fprintf(stdout, "%s: %d hook entries already current in %s\n", a.Name, entries, a.ConfigPath())
 		}
-		for _, d := range a.Degradations(rs.Rules) {
+		for _, d := range a.Degradations(rs.Effective()) {
 			fmt.Fprintf(stdout, "%s: %s\n", a.Name, d)
 		}
 		for _, q := range a.Quirks {


### PR DESCRIPTION
Closes #51.

Four places decided whether a rule could fire, and no module owned the question. `Match` checked `ShadowedBy` while `Matches` checked `Enabled`, so the two halves were split inside `internal/rule` itself. `cmdAdvise` and `Adapter.Degradations` each spelled out `!r.Enabled || r.ShadowedBy != nil` in full, which made `internal/harness` read two `*rule.Rule` fields to answer a rule question.

- `Rule.Live` reports enabled and not shadowed. Every caller acting on the distinction now asks there.
- `Ruleset.Effective` returns the live subset in delivery order.
- `Match` checks `Live` inline rather than iterating `Effective`. The engine is the hot path and the selector would allocate a second slice per event.
- `Matches` answers whether the matcher selects the payload, and nothing else.
- `Degradations` reports on the rules it is given. Its three callers in `main.go` pass `rs.Effective()`.
- `printRuleset` is unchanged. It reports per-rule status, which is not a liveness question.

`Evaluate` and the Outcome derivation follow in a separate issue.

Behaviour-preserving, so no new test. Per ADR 0009 the existing `testdata/script` cases are the regression net, `tiers.txtar`, `advise.txtar`, `sync_claude.txtar`, and `doctor.txtar` in particular.