### PR TITLE
refactor(rule): derive the Outcome once, behind the ruleset (#52)

### DIFF
--- a/internal/rule/evaluate.go
+++ b/internal/rule/evaluate.go
@@ -12,23 +12,35 @@ type Payload struct {
 	Fields map[string]string
 }
 
-// Match returns the rules of the Effective ruleset that select the payload, in
-// delivery order: tier order, then alphabetical within a tier. Liveness is
-// checked inline rather than over rs.Effective(), because this is the hot path
-// and the selector would allocate a second slice per event.
-func (rs *Ruleset) Match(p Payload) []*Rule {
-	var out []*Rule
+// Evaluate runs the payload against the Effective ruleset and answers with both
+// halves of what an event produces: the rules that matched, in delivery order
+// (tier order, then alphabetical within a tier), and the Outcome, allow, warn
+// or block, where one block among several matches makes it block. A caller
+// deriving the Outcome for itself would be a second answer to the same
+// question, free to disagree with this one, and test exists to say what hook
+// will do.
+//
+// Liveness is checked inline rather than over rs.Effective(), because this is
+// the hot path and the selector would allocate a second slice per event.
+func (rs *Ruleset) Evaluate(p Payload) (matched []*Rule, outcome string) {
+	outcome = "allow"
 	for _, r := range rs.Rules {
-		if r.Live() && r.Matches(p) {
-			out = append(out, r)
+		if !r.Live() || !r.matches(p) {
+			continue
+		}
+		matched = append(matched, r)
+		if r.Action == "block" {
+			outcome = "block"
+		} else if outcome == "allow" {
+			outcome = "warn"
 		}
 	}
-	return out
+	return matched, outcome
 }
 
-// Matches reports whether this rule's matcher selects the payload. Whether the
+// matches reports whether this rule's matcher selects the payload. Whether the
 // rule can fire at all is Live's question, not this one's.
-func (r *Rule) Matches(p Payload) bool {
+func (r *Rule) matches(p Payload) bool {
 	if r.Event != p.Event {
 		return false
 	}

--- a/internal/rule/trust.go
+++ b/internal/rule/trust.go
@@ -35,6 +35,21 @@ func isTrusted(root string) bool {
 	return slices.Contains(strings.Split(string(data), "\n"), root)
 }
 
+// TrustNotice is what a skipped Project-shared tier owes the user, and "" when
+// nothing was skipped. The tiers and the root are the ruleset's own state, so
+// the sentence is written here rather than assembled by every caller that has
+// to print it.
+func (rs *Ruleset) TrustNotice() string {
+	for _, t := range rs.Tiers {
+		if t.Skipped {
+			return fmt.Sprintf(
+				"handrail: skipping the untrusted Project-shared rules in %s; run handrail trust to enable them",
+				rs.Root)
+		}
+	}
+	return ""
+}
+
 // Trust records this ruleset's project root as trusted, reporting whether that
 // was new. The load already knows the root, so a caller holding a ruleset never
 // has to work out which path the grant is keyed by.

--- a/main.go
+++ b/main.go
@@ -607,8 +607,19 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		var payload rule.Payload
 		var cwd string
 		if payload, cwd, err = a.Normalize(event, data); err == nil {
-			message, block := evaluate(payload, cwd)
-			return a.Deliver(event, message, block, stdout, stderr)
+			// The payload names the directory the event happened in; the process's
+			// own is the fallback for a harness that leaves it out. That is process
+			// state rather than payload, so it is answered here and not in Normalize.
+			if !filepath.IsAbs(cwd) {
+				if cwd, err = os.Getwd(); err != nil {
+					return a.Deliver(event,
+						fmt.Sprintf("handrail: no working directory, so no rule was evaluated: %v", err),
+						false, stdout, stderr)
+				}
+			}
+			rs := rule.Load(cwd)
+			matched, outcome := rs.Evaluate(payload)
+			return a.Deliver(event, agentMessage(rs, matched), outcome == "block", stdout, stderr)
 		}
 	}
 	return a.Deliver(event,
@@ -616,24 +627,13 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		false, stdout, stderr)
 }
 
-// evaluate merges the tiers and collects everything the agent should hear: the
-// matched messages, then whatever handrail had to skip to get there.
-func evaluate(payload rule.Payload, cwd string) (message string, block bool) {
-	// The payload names the directory the event happened in; the process's own
-	// is the fallback for a harness that leaves it out.
-	if !filepath.IsAbs(cwd) {
-		var err error
-		if cwd, err = os.Getwd(); err != nil {
-			return fmt.Sprintf("handrail: no working directory, so no rule was evaluated: %v", err), false
-		}
-	}
-	rs := rule.Load(cwd)
-
+// agentMessage is the wire format the hook path delivers: everything the agent
+// should hear, which is the matched messages, then whatever handrail had to
+// skip to get there. It stays in the CLI because it is the hook command's own
+// output format, with one caller and nothing to disagree with.
+func agentMessage(rs *rule.Ruleset, matched []*rule.Rule) string {
 	var sections []string
-	for _, r := range rs.Match(payload) {
-		if r.Action == "block" {
-			block = true
-		}
+	for _, r := range matched {
 		sections = append(sections, fmt.Sprintf("handrail %s: %s (%s)\n%s", r.Action, r.Name, r.Tier, r.Message))
 	}
 	// Loud fail-open: a rule that cannot be parsed is skipped, and the skipping
@@ -641,10 +641,10 @@ func evaluate(payload rule.Payload, cwd string) (message string, block bool) {
 	for _, p := range rs.Problems {
 		sections = append(sections, fmt.Sprintf("handrail: skipped the broken rule %s: %s", p.Path, p.Message))
 	}
-	if notice := trustNotice(rs); notice != "" {
+	if notice := rs.TrustNotice(); notice != "" {
 		sections = append(sections, notice)
 	}
-	return strings.Join(sections, "\n\n"), block
+	return strings.Join(sections, "\n\n")
 }
 
 // loadRules reads the tiers that apply to the working directory and reports an
@@ -655,7 +655,7 @@ func loadRules(stderr io.Writer) (*rule.Ruleset, error) {
 		return nil, err
 	}
 	rs := rule.Load(cwd)
-	if notice := trustNotice(rs); notice != "" {
+	if notice := rs.TrustNotice(); notice != "" {
 		fmt.Fprintln(stderr, notice)
 	}
 	return rs, nil
@@ -677,19 +677,6 @@ func loadValidRules(stderr io.Writer) (*rule.Ruleset, int) {
 		return nil, 1
 	}
 	return rs, 0
-}
-
-// trustNotice is what a skipped Project-shared tier owes the user, and "" when
-// nothing was skipped.
-func trustNotice(rs *rule.Ruleset) string {
-	for _, t := range rs.Tiers {
-		if t.Skipped {
-			return fmt.Sprintf(
-				"handrail: skipping the untrusted Project-shared rules in %s; run handrail trust to enable them",
-				rs.Root)
-		}
-	}
-	return ""
 }
 
 func writeJSON(stdout, stderr io.Writer, v any) int {
@@ -883,16 +870,13 @@ func cmdTest(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return code
 	}
 
-	out := testOutput{Outcome: "allow", Matched: []testMatch{}}
-	for _, r := range rs.Match(payload) {
+	// The same call the hook path makes, so what test reports is what hook does.
+	matched, outcome := rs.Evaluate(payload)
+	out := testOutput{Outcome: outcome, Matched: []testMatch{}}
+	for _, r := range matched {
 		out.Matched = append(out.Matched, testMatch{
 			Rule: r.Name, Tier: r.Tier, Action: r.Action, Message: r.Message,
 		})
-		if r.Action == "block" {
-			out.Outcome = "block"
-		} else if out.Outcome == "allow" {
-			out.Outcome = "warn"
-		}
 	}
 
 	if *asJSON {


### PR DESCRIPTION
Closes #52.

The hot path's domain logic lived in the CLI. `evaluate` merged the tiers, walked `Match`, and derived a block boolean; `cmdTest` walked `Match` again and derived the same Outcome from its own lattice. Two answers to one question, free to disagree, and `test` exists to say what `hook` will do. `trustNotice` read `rs.Tiers[].Skipped` and named `rs.Root`, so `main.go` reached into tier state to answer a ruleset question.

`internal/rule`:

- `Ruleset.Evaluate` returns the matched rules in delivery order and the Outcome: allow, warn, or block, where one block among several matches makes it block. Two return values rather than a struct, because Outcome is the name of the string and a struct would need a second noun invented for the pair.
- `Match` is absorbed into `Evaluate`, and `Matches` is now unexported. Evaluation is one exported name in place of three.
- `Ruleset.TrustNotice` returns what a skipped Project-shared tier owes the user, and "" when nothing was skipped.
- `match.go` is renamed `evaluate.go`, after the name it now exports.

`main.go`:

- `evaluate` is deleted. `cmdHook` keeps the missing-cwd fallback, which is process state rather than payload and does not belong in `Normalize`, then calls `rule.Load`, `rs.Evaluate`, `agentMessage`, and `Deliver`.
- `agentMessage` holds the agent wire format. It stays in the CLI: one caller, and it is the `hook` command's own output format.
- `cmdTest` builds `testOutput` from the same two return values, and its own lattice is gone.
- `trustNotice` is deleted. `loadRules` and `agentMessage` call `rs.TrustNotice()`.

Behaviour-preserving, so no new test. Per ADR 0009 the existing `testdata/script` cases are the regression net: `hook_claude.txtar`, `hook_codex.txtar`, `hook_failopen.txtar`, `hook_untrusted.txtar`, and the six `test_*.txtar` cases.