### PR TITLE
docs(context): state that an Outcome takes the strongest Action (#56)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,8 +52,8 @@ _Avoid_: conflating with the Advisor
 What a matched rule does: warn (proceed, but inject the rule's message into the agent's context) or block (deny, with the rule's message as the reason). Allow is the absence of a match, not an action.
 
 **Outcome**:
-What evaluating one event against the Effective ruleset produces: allow, warn, or block. Exactly three, and allow is the absence of a match rather than an Action. Among several matched rules, one block makes the Outcome block.
-_Avoid_: result, verdict, conflating with Action
+What evaluating one event against the Effective ruleset produces: allow, warn, or block. Exactly three. An Outcome takes the strongest Action among the matched rules, so warn and block are deliberately the Action's own values; allow is the absence of a match rather than an Action, and belongs to no rule.
+_Avoid_: result, verdict, calling one matched rule's Action the Outcome
 
 **Tool kind**:
 The canonical cross-harness classification of a tool, assigned by the Adapter: shell, file_edit, file_read, mcp, other.


### PR DESCRIPTION
Closes #56.

The Action and Outcome entries in `CONTEXT.md` share the values warn and block, and the Outcome entry told the reader to avoid "conflating with Action" without saying what conflating meant. Read against the shared values, the line looked like it forbade them.

It does not. An Outcome takes the strongest Action among the matched rules, which is why the two roles share those values on purpose. Allow is the one value no Action can hold: it is the absence of a match and belongs to no rule. "Strongest" is the glossary's own word, already used by Degradation to name the block, then warn, then skip ordering.

The `_Avoid_` line now names the mistake it was guarding against: calling one matched rule's Action the Outcome.

The Action entry is unchanged. Docs only, no code touched.

Groundwork for naming the warn and block vocabulary in code, which needs the glossary to say whether the two roles share values deliberately.