### PR TITLE
refactor(rule): name the warn and block vocabulary (#57)

### DIFF
--- a/internal/harness/advise.go
+++ b/internal/harness/advise.go
@@ -71,7 +71,7 @@ func (a Adapter) Advise(r *rule.Rule) (Advice, bool) {
 	// nothing to promote to. Conditions AND together, and a native entry is one
 	// pattern: two conditions cannot be one entry, and either alone blocks more
 	// than the pair does.
-	if r.Action != "block" || r.Event != "PreToolUse" || len(r.Conditions) != 1 {
+	if r.Action != rule.Block || r.Event != "PreToolUse" || len(r.Conditions) != 1 {
 		return Advice{}, false
 	}
 	terms := r.Conditions[0].Any

--- a/internal/harness/sync.go
+++ b/internal/harness/sync.go
@@ -272,7 +272,7 @@ func (d Degradation) String() string {
 func (a Adapter) Degradations(rules []*rule.Rule) []Degradation {
 	var out []Degradation
 	for _, r := range rules {
-		if r.Action == "block" && !a.canBlock(r.Event) {
+		if r.Action == rule.Block && !a.canBlock(r.Event) {
 			out = append(out, Degradation{
 				Rule: r.Name, From: "block", To: "warn", Reason: a.blockReason(r.Event),
 			})

--- a/internal/rule/evaluate.go
+++ b/internal/rule/evaluate.go
@@ -23,16 +23,16 @@ type Payload struct {
 // Liveness is checked inline rather than over rs.Effective(), because this is
 // the hot path and the selector would allocate a second slice per event.
 func (rs *Ruleset) Evaluate(p Payload) (matched []*Rule, outcome string) {
-	outcome = "allow"
+	outcome = Allow
 	for _, r := range rs.Rules {
 		if !r.Live() || !r.matches(p) {
 			continue
 		}
 		matched = append(matched, r)
-		if r.Action == "block" {
-			outcome = "block"
-		} else if outcome == "allow" {
-			outcome = "warn"
+		if r.Action == Block {
+			outcome = Block
+		} else if outcome == Allow {
+			outcome = Warn
 		}
 	}
 	return matched, outcome

--- a/internal/rule/hookify.go
+++ b/internal/rule/hookify.go
@@ -179,7 +179,7 @@ func convertHookify(path string) (name, file string, err error) {
 	}
 	// Upstream treats anything that is not "block" as a warning.
 	if action != "block" {
-		action = "warn"
+		action = Warn
 	}
 
 	file = renderRule(ev, kind, action, enabled, terms, strings.TrimSpace(body))

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -8,6 +8,16 @@ import (
 	"strings"
 )
 
+// The Action and Outcome vocabulary, one set for both: an Outcome takes the
+// strongest Action among the matched rules, so warn and block are the same two
+// values under either name. Allow is exported although no Rule.Action may hold
+// it, because it belongs to the vocabulary rather than to one field.
+const (
+	Allow = "allow"
+	Warn  = "warn"
+	Block = "block"
+)
+
 // Rule is one guardrail: a matcher (event, kind, conditions) and the message
 // delivered when it matches. Identity is the file's basename.
 type Rule struct {
@@ -101,7 +111,7 @@ func Parse(name string, data []byte) (*Rule, error) {
 		return nil, err
 	}
 
-	r := &Rule{Name: name, Action: "warn", Enabled: true, Message: strings.TrimSpace(body)}
+	r := &Rule{Name: name, Action: Warn, Enabled: true, Message: strings.TrimSpace(body)}
 	seen := make(map[string]bool, len(doc.mapping))
 	for _, kv := range doc.mapping {
 		if seen[kv.key] {
@@ -128,7 +138,7 @@ func Parse(name string, data []byte) (*Rule, error) {
 			if err := scalarInto(kv, &r.Action); err != nil {
 				return nil, err
 			}
-			if r.Action != "warn" && r.Action != "block" {
+			if r.Action != Warn && r.Action != Block {
 				return nil, fmt.Errorf("line %d: unknown action %q", kv.line, r.Action)
 			}
 		case "enabled":

--- a/internal/rule/trust.go
+++ b/internal/rule/trust.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 )
 
-// The trust registry is one project root per line in the XDG state dir. It
-// gates the Project-shared tier only: cloning a repo cannot put its committed
-// rules in front of the agent until the user grants that path once.
+// Trust end to end: the registry that records it, and what the user is told
+// when a tier goes untrusted. The registry is one project root per line in the
+// XDG state dir, and it gates the Project-shared tier only: cloning a repo
+// cannot put its committed rules in front of the agent until the user grants
+// that path once.
 
 func trustFile() string {
 	dir := xdgSubdir("XDG_STATE_HOME", filepath.Join(".local", "state"))

--- a/main.go
+++ b/main.go
@@ -619,7 +619,7 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			}
 			rs := rule.Load(cwd)
 			matched, outcome := rs.Evaluate(payload)
-			return a.Deliver(event, agentMessage(rs, matched), outcome == "block", stdout, stderr)
+			return a.Deliver(event, agentMessage(rs, matched), outcome == rule.Block, stdout, stderr)
 		}
 	}
 	return a.Deliver(event,
@@ -898,7 +898,7 @@ func cmdTest(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "outcome: %s\n", out.Outcome)
 	}
 
-	if out.Outcome == "block" {
+	if out.Outcome == rule.Block {
 		return 2
 	}
 	return 0


### PR DESCRIPTION
Closes #57.

warn and block crossed the `internal/rule` boundary as bare literals four times, and appeared as literals again inside the package. One closed vocabulary from the glossary spelled two conventions.

## What changed

- `internal/rule` gains `Allow`, `Warn` and `Block`: one set for both roles, since an Outcome takes the strongest Action among the matched rules (#56). `Allow` is exported although no `Rule.Action` may hold it, because the set belongs to the vocabulary rather than to one field.
- `evaluate.go`, `Parse`'s default action and its action validation use them.
- `internal/harness/advise.go` and `sync.go`, and `cmdHook`'s block flag and `cmdTest`'s exit-code check in `main.go`, compare against `rule.Block`.
- `hookify.go`'s read of upstream hookify's `action` field keeps its literal. The Importer is a mapping between two formats (ADR 0008), so naming upstream's value with ours would assert the equivalence the mapping exists to not assume.
- `trust.go`'s header widens to cover trust end to end, the registry and what the user is told when a tier goes untrusted, so `TrustNotice` reads as belonging where it sits.

`Evaluate`'s signature is unchanged and `outcome` stays a `string`: its values are one vocabulary with Action, so a defined type would need a conversion written at the line where the domain says the two meet.

## Tests

Behaviour-preserving, so no new test. ADR 0009 stands: the `hook_*.txtar` and `test_*.txtar` cases are the regression net. The `--json` contract in ADR 0006 is untouched, because no value changes.