### PR TITLE
refactor(harness): declare the Promotion's scope on the Adapter

### DIFF
--- a/internal/harness/advise.go
+++ b/internal/harness/advise.go
@@ -16,12 +16,22 @@ type Advice struct {
 	Mechanism string
 	Entry     string
 	Location  string
-	Caveats   []string
+	// WidensScope reports that pasting the entry gives the rule more reach than
+	// its tier gives it. The sentence saying so is the caller's to render,
+	// because it names the repo, which the Advisor has no reason to know.
+	WidensScope bool
+	Caveats     []string
 }
 
 // The rule stays the message-bearing layer either way, so every promotion says
 // so: a native deny states no reason, and an agent that hears none retries.
 const silentCaveat = "the native entry denies without a message, so keep the rule: the hook path is what tells the agent why"
+
+// scopeUser is a mechanism whose entries live at the user level and therefore
+// reach every repo on the machine. Promoting anything narrower than a Global
+// rule into one widens the rule's reach. Declared per harness rather than
+// assumed, because a mechanism scoped to a single project would not.
+const scopeUser = "user"
 
 // promotion is one harness's translation knowledge: the mechanism a rule can be
 // promoted into, where its entries live, and how a condition is spelled there.
@@ -31,6 +41,10 @@ type promotion struct {
 	mechanism string   // what the harness calls it
 	file      string   // where entries go, relative to the user-level directory
 	caveats   []string // what every promotion to this harness carries
+	// scope says how far an entry reaches once pasted. A string rather than a
+	// bool because the table test counts the parts a Promotion declares, and an
+	// unset bool reads the same as a declared narrow one.
+	scope string
 	// entries spells one condition, and names the caveat that spelling earns.
 	entries func(*rule.Rule, rule.Term) (spelled []string, caveat string, ok bool)
 }
@@ -66,7 +80,11 @@ func (a Adapter) Advise(r *rule.Rule) (Advice, bool) {
 	// A deny list is a disjunction, which is exactly what an any group is, so
 	// each branch earns its own entry. One untranslatable branch sinks the rule:
 	// the remaining entries would be a guardrail with a hole in it.
-	adv := Advice{Mechanism: p.mechanism, Location: target}
+	adv := Advice{
+		Mechanism:   p.mechanism,
+		Location:    target,
+		WidensScope: p.scope == scopeUser && r.Tier != rule.TierGlobal,
+	}
 	adv.Caveats = append(adv.Caveats, silentCaveat)
 	adv.Caveats = append(adv.Caveats, p.caveats...)
 	var entries []string

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -41,13 +41,14 @@ var adapters = []Adapter{
 			"disableAllHooks and cloud sessions bypass handrail entirely",
 		},
 		// Permission rules live in the same file sync writes, under a different key.
-		promotion: promotion{mechanism: "permissions.deny", file: "settings.json", entries: claudeEntries},
+		promotion: promotion{mechanism: "permissions.deny", file: "settings.json", scope: scopeUser, entries: claudeEntries},
 	},
 	{
 		Name: "codex", title: "Codex CLI", dir: ".codex", homeEnv: "CODEX_HOME", file: "hooks.json",
 		promotion: promotion{
 			mechanism: "execpolicy prefix_rule",
 			file:      filepath.Join("rules", "default.rules"),
+			scope:     scopeUser,
 			caveats: []string{
 				"codex exec --ignore-rules bypasses execpolicy, so the backstop is absent there while the rule still fires",
 			},

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -89,23 +89,29 @@ func TestEveryAdapterFollowsItsRelocationVariable(t *testing.T) {
 	}
 }
 
-// A Promotion is three declarations that only mean something together: the
-// mechanism names it, the file says where its entries are pasted, and entries
-// spells them. Half of one is a harness that advertises a mechanism it cannot
-// write an entry for, or writes entries with nowhere to put them. Declaring
-// none is how a harness says it has no Promotion, so only the mixture is wrong,
-// and only a walk of the table can see it.
+// A Promotion is four declarations that only mean something together: the
+// mechanism names it, the file says where its entries are pasted, the scope
+// says how far one reaches once pasted, and entries spells them. Part of one is
+// a harness that advertises a mechanism it cannot write an entry for, writes
+// entries with nowhere to put them, or leaves handrail to guess how far they
+// carry. Declaring none is how a harness says it has no Promotion, so only the
+// mixture is wrong, and only a walk of the table can see it.
 func TestEveryAdapterDeclaresItsPromotionWhole(t *testing.T) {
 	for _, a := range Adapters() {
 		t.Run(a.Name, func(t *testing.T) {
 			declared := 0
-			for _, part := range []bool{a.promotion.mechanism != "", a.promotion.file != "", a.promotion.entries != nil} {
+			for _, part := range []bool{
+				a.promotion.mechanism != "",
+				a.promotion.file != "",
+				a.promotion.scope != "",
+				a.promotion.entries != nil,
+			} {
 				if part {
 					declared++
 				}
 			}
-			if declared != 0 && declared != 3 {
-				t.Errorf("%s declares %d of the 3 Promotion parts: %+v", a.Name, declared, a.promotion)
+			if declared != 0 && declared != 4 {
+				t.Errorf("%s declares %d of the 4 Promotion parts: %+v", a.Name, declared, a.promotion)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -362,7 +362,6 @@ func cmdAdvise(args []string, stdout, stderr io.Writer) int {
 
 	out := []adviceOutput{}
 	for _, r := range targets {
-		widening := scopeWidening(r.Tier, rs.Root)
 		for _, a := range harness.Adapters() {
 			if *only != "" && a.Name != *only {
 				continue
@@ -374,7 +373,7 @@ func cmdAdvise(args []string, stdout, stderr io.Writer) int {
 			out = append(out, adviceOutput{
 				Rule: r.Name, Tier: r.Tier, Harness: a.Name,
 				Mechanism: adv.Mechanism, Entry: adv.Entry, Location: adv.Location,
-				ScopeWidening: widening, Caveats: adv.Caveats,
+				ScopeWidening: scopeNote(adv.WidensScope, rs.Root), Caveats: adv.Caveats,
 			})
 		}
 	}
@@ -472,11 +471,11 @@ func relTo(root, path string) string {
 	return rel
 }
 
-// scopeWidening states what a promotion changes about a rule's reach. Native
-// entries are user-level, so promoting a project-tier rule spreads it to every
-// repo on the machine; a Global rule was already there.
-func scopeWidening(tier, root string) *string {
-	if tier == rule.TierGlobal {
+// scopeNote renders what a promotion changes about a rule's reach. Whether the
+// entry widens it is the Advisor's answer, because only the Adapter knows how
+// far its mechanism reaches; naming the repo is this side's job.
+func scopeNote(widens bool, root string) *string {
+	if !widens {
 		return nil
 	}
 	s := fmt.Sprintf("this rule applies only in %s, and the entry applies in every repo on this machine", root)


### PR DESCRIPTION
Follow-on to #60, which moved the Promotion onto the Adapter. One piece of translation knowledge stayed behind in the CLI.

## What changed

`main.go`'s `scopeWidening` decided, for every harness, that a promoted rule widens its reach unless the rule is Global. That is a claim about how far a harness's mechanism carries, which only the Adapter knows. A harness whose mechanism were project-scoped would have got the sentence anyway, and nothing in the table would have said otherwise.

`promotion` now declares `scope`, and both current harnesses declare `scopeUser`: their entries live at the user level and reach every repo on the machine. `Advise` answers the question with `p.scope == scopeUser && r.Tier != rule.TierGlobal` and reports it as `Advice.WidensScope`.

`main.go` keeps the half that is genuinely its own. `scopeNote` renders the sentence, because the sentence names the repo and the Advisor has no reason to know it.

`advise` recommends exactly what it recommended before, on both harnesses and every tier.

## Tests

`TestEveryAdapterDeclaresItsPromotionWhole` now counts four parts rather than three. Leaving `scope` unset is the case it catches: a harness that declares a mechanism and a file and leaves handrail to guess how far its entries carry. The comment says so.

`scope` is a string rather than a bool for that test's sake. An unset bool reads the same as a declared narrow one, so the table could not tell a missing declaration from a real answer.

## Known gap

Nothing validates `scope` against a set of known values, so a typo reads as "does not widen". A second scope value would be the point to fix that; with one, a validator has nothing to compare against.

## Checks

`task test`, `task lint`, and `task cover` (97.9%) pass locally.