### PR TITLE
test(harness): reject a Promotion scope handrail does not know

### DIFF
--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -117,6 +117,28 @@ func TestEveryAdapterDeclaresItsPromotionWhole(t *testing.T) {
 	}
 }
 
+// Wholeness is not enough for scope, because Advise compares it against the one
+// scope handrail knows and reads anything else as narrower. A misspelling is
+// therefore a declaration the table accepts and the Advisor answers backwards:
+// the entry still reaches every repo, and the user is no longer told so before
+// pasting it. On the harnesses sync writes for, advise.txtar and
+// advise_json.txtar catch that; on the next harness added, nothing does until
+// someone writes its cases, which is the gap only a walk of the table closes.
+//
+// Comparing against scopeUser rather than a set is what having one scope means.
+// A harness whose mechanism reaches less has to add the constant and widen this
+// test, which is the point where that harness's reach gets thought about.
+func TestEveryPromotionDeclaresAScopeHandrailKnows(t *testing.T) {
+	for _, a := range Adapters() {
+		t.Run(a.Name, func(t *testing.T) {
+			if a.promotion.scope != "" && a.promotion.scope != scopeUser {
+				t.Errorf("%s declares scope %q, which is not a scope handrail knows: Advise reads it as narrower than %q and drops the widening warning",
+					a.Name, a.promotion.scope, scopeUser)
+			}
+		})
+	}
+}
+
 func TestWriteReportsAnUnusableParent(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(file, []byte("{}\n"), 0o600); err != nil {


### PR DESCRIPTION
Closes the gap named in #63's own body: nothing validated `promotion.scope` against a known value, so an unrecognised one silently read as "does not widen".

## The defect

`Advise` compares `p.scope` against `scopeUser`, the one scope handrail knows, and reads anything else as narrower. A misspelling is therefore a declaration the table accepts and the Advisor answers backwards: the entry still gets pasted into a user-level file and still reaches every repo on the machine, and the project-tier user is no longer told so.

`TestEveryAdapterDeclaresItsPromotionWhole` counts `scope != ""`, so any string passes it. That test exists for the harness the compiled binary cannot reach, and this is exactly that harness.

## What the diagnosis found

Two experiments, both deterministic and under a second:

- Misspell `scope` on claude or codex and `advise.txtar` and `advise_json.txtar` both go red. The two shipped harnesses are already covered end to end.
- Add a third adapter to the table carrying `scope: "usr"` and every subtest of `TestEveryAdapterDeclaresItsPromotionWhole` passes, gemini included. Nothing anywhere catches it.

So the live harnesses were never at risk. The gap was the next harness added to the table before anyone writes its testscript cases, and the failure direction there is the unsafe one.

At the unit seam the symptom is exact: same rule, same entry, same paste location, `WidensScope` flips true to false on the typo alone.

## What changed

One sibling test, `TestEveryPromotionDeclaresAScopeHandrailKnows`, walking the table and rejecting a declared scope that is not one handrail knows. Written against the typo first: red on `"usr"`, red on the case-only `"Usr"`, red on the third-adapter case that nothing else caught, green on the real table.

It compares against `scopeUser` rather than a set, because that is what having one scope means. A harness whose mechanism reaches less has to add the constant and widen this test, which is the point where that harness's reach gets thought about. A set declared in non-test code with only this test for a caller is the abstraction ADR 0009 rejects.

## Not changed

- `r.Tier != rule.TierGlobal`, on the same line, is unvalidated too, but an unknown tier reads as narrower than global and over-warns. Wrong in the safe direction, and `Tier` is only ever assigned by `rule.Load` from three literals.
- `hookify.go`'s `if action != "block" { action = Warn }` maps a user-supplied field with no error path, and its comment says it mirrors upstream semantics deliberately. That is the Importer being a mapping rather than an assertion of equivalence (ADR 0008).

Every other closed vocabulary in the repo, event, kind, action, operator, field, and harness name, is already rejected at parse time.

## Checks

Test-only, so no behaviour changes and `advise` recommends what it recommended before. `task test`, `task lint`, and `task cover` (97.8%) pass locally.