### PR TITLE
refactor: drop duplicated vocabulary, unreachable code, and a stdlib reimplementation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,9 @@ _Avoid_: hook, policy, check
 Where a rule lives and whom it applies to. Three tiers: Global (user-level, all projects), Project-shared (committed to the repo), Project-personal (local, gitignored). Precedence is most specific wins: Global < Project-shared < Project-personal. Tiers are convenience layering, not a security boundary.
 _Avoid_: scope, level
 
+**Project root**:
+The directory a working directory's project tiers are discovered at and its Trust grant is keyed by: the repo root, or the working directory itself outside a repo, with symlinks resolved so that one project has one identity.
+
 **Shadowing**:
 A rule file in a higher-precedence tier replacing a same-named rule in a lower tier wholesale. There is no field-level merging; the shadowing file is the effective rule.
 
@@ -31,7 +34,11 @@ _Avoid_: conflating with the rules that match one event, which is one event's ma
 The selecting half of a rule: an event name, an optional tool kind, and a list of conditions.
 
 **Condition**:
-One field test inside a matcher: a single operator applied to one canonical payload field. Conditions AND together; a one-level any group expresses OR.
+One entry of a matcher's condition list: one or more Terms, which OR together. Conditions AND together, so a matcher selects only when every one of them is satisfied. A condition written as a bare field test is a one-Term condition; `any:` is how a rule file writes more than one.
+
+**Term**:
+One field test: a single operator applied to one canonical payload field.
+_Avoid_: condition, when the single field test is meant
 
 **Event model**:
 The harness-neutral set of lifecycle events rules are written against.

--- a/internal/rule/exclude.go
+++ b/internal/rule/exclude.go
@@ -11,7 +11,7 @@ import (
 
 // excludeLine keeps the Project-personal tier out of version control. Git wants
 // forward slashes here whatever the platform, so it is not filepath.Join.
-const excludeLine = dirName + "/" + localName + "/"
+const excludeLine = sharedName + "/" + localName + "/"
 
 // readExclude reads root's exclude file and names it. Outside a git working
 // tree there is no such file, and the empty path says so: that is not the same

--- a/internal/rule/exclude.go
+++ b/internal/rule/exclude.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 )
 
-// excludeLine keeps the Project-personal tier out of version control.
-const excludeLine = ".handrail/local/"
+// excludeLine keeps the Project-personal tier out of version control. Git wants
+// forward slashes here whatever the platform, so it is not filepath.Join.
+const excludeLine = dirName + "/" + localName + "/"
 
 // readExclude reads root's exclude file and names it. Outside a git working
 // tree there is no such file, and the empty path says so: that is not the same

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -108,9 +108,8 @@ func Load(cwd string) *Ruleset {
 	return rs
 }
 
-// The two project-tier directory names, written once: the exclude line and the
-// walk's skip are both spelled from them, so renaming either directory cannot
-// leave one of the three sites behind still compiling.
+// The project tiers' directory names, written once so that excludeLine and the
+// walk's skip cannot drift from the paths they are meant to describe.
 const (
 	dirName   = ".handrail"
 	localName = "local"

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -108,15 +108,17 @@ func Load(cwd string) *Ruleset {
 	return rs
 }
 
-// The project tiers' directory names, written once so that excludeLine and the
-// walk's skip cannot drift from the paths they are meant to describe.
+// The two directory names every path in this package is built from: excludeLine
+// and the walk's skip are spelled from them rather than repeating the literals.
+// The CLI's own messages name the same paths in prose, so a rename is still a
+// grep, not a one-line edit.
 const (
-	dirName   = ".handrail"
-	localName = "local"
+	sharedName = ".handrail"
+	localName  = "local"
 )
 
 // sharedDir is the Project-shared tier's directory, at the project root.
-func sharedDir(root string) string { return filepath.Join(root, dirName) }
+func sharedDir(root string) string { return filepath.Join(root, sharedName) }
 
 // LocalDir is the Project-personal tier's directory, inside the shared one so a
 // single exclude line keeps it out of version control. Exported for import,

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -108,13 +108,21 @@ func Load(cwd string) *Ruleset {
 	return rs
 }
 
+// The two project-tier directory names, written once: the exclude line and the
+// walk's skip are both spelled from them, so renaming either directory cannot
+// leave one of the three sites behind still compiling.
+const (
+	dirName   = ".handrail"
+	localName = "local"
+)
+
 // sharedDir is the Project-shared tier's directory, at the project root.
-func sharedDir(root string) string { return filepath.Join(root, ".handrail") }
+func sharedDir(root string) string { return filepath.Join(root, dirName) }
 
 // LocalDir is the Project-personal tier's directory, inside the shared one so a
 // single exclude line keeps it out of version control. Exported for import,
 // which writes into the tier without loading it.
-func LocalDir(root string) string { return filepath.Join(sharedDir(root), "local") }
+func LocalDir(root string) string { return filepath.Join(sharedDir(root), localName) }
 
 // configDir is the Global tier's directory: XDG on every Unix platform,
 // including macOS, following the git and gh dotfiles precedent rather than
@@ -155,7 +163,7 @@ func load(dir string, skipLocal bool) ([]*Rule, []Problem) {
 			return nil
 		}
 		if d.IsDir() {
-			if skipLocal && d.Name() == "local" && filepath.Dir(p) == dir {
+			if skipLocal && d.Name() == localName && filepath.Dir(p) == dir {
 				return fs.SkipDir
 			}
 			return nil

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -56,23 +57,24 @@ type Term struct {
 	line  int
 }
 
-// Events lists the six core events, in the order sync writes hook entries for
-// them. Only sync needs the list; it is a function rather than a package
-// variable so the hook path pays no startup cost for a slice it never reads.
+// events holds the six core events, in the order sync writes hook entries for
+// them. An array of constants is static data, so nothing runs before main to
+// build it: the hook path pays for every byte of startup work.
+var events = [...]string{"PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd", "Stop"}
+
+// Events lists the six core events. Only sync needs the list, and it gets a
+// copy so no caller can reorder the array IsEvent reads.
 func Events() []string {
-	return []string{"PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd", "Stop"}
+	return slices.Clone(events[:])
 }
 
-// These four sets are switches rather than package-level maps so that nothing
-// runs before main: the hook path pays for every byte of startup work.
+// The three sets below are switches rather than package-level maps for the same
+// reason: nothing may run before main.
 
-// IsEvent reports whether name is one of the six core events.
+// IsEvent reports whether name is one of the six core events. Slicing the array
+// allocates nothing, so the hook path stays free of startup work.
 func IsEvent(name string) bool {
-	switch name {
-	case "PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd", "Stop":
-		return true
-	}
-	return false
+	return slices.Contains(events[:], name)
 }
 
 // IsKind reports whether name is a canonical tool kind.

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -58,8 +58,8 @@ type Term struct {
 }
 
 // events holds the six core events, in the order sync writes hook entries for
-// them. An array of constants is static data, so nothing runs before main to
-// build it: the hook path pays for every byte of startup work.
+// them. The hook path pays for every byte of startup work, so this is an array
+// of constants: static data the linker lays out, with no init to run.
 var events = [...]string{"PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd", "Stop"}
 
 // Events lists the six core events. Only sync needs the list, and it gets a
@@ -69,8 +69,9 @@ func Events() []string { return slices.Clone(events[:]) }
 // IsEvent reports whether name is one of the six core events.
 func IsEvent(name string) bool { return slices.Contains(events[:], name) }
 
-// The three sets below are switches rather than package-level maps for the same
-// reason: nothing may run before main.
+// The three sets below stay switches: each is written down once, so unlike the
+// events there is no second copy for it to drift from. Switch or array, the
+// rule is the same one: nothing may run before main.
 
 // IsKind reports whether name is a canonical tool kind.
 func IsKind(name string) bool {

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -64,18 +64,13 @@ var events = [...]string{"PreToolUse", "PostToolUse", "UserPromptSubmit", "Sessi
 
 // Events lists the six core events. Only sync needs the list, and it gets a
 // copy so no caller can reorder the array IsEvent reads.
-func Events() []string {
-	return slices.Clone(events[:])
-}
+func Events() []string { return slices.Clone(events[:]) }
+
+// IsEvent reports whether name is one of the six core events.
+func IsEvent(name string) bool { return slices.Contains(events[:], name) }
 
 // The three sets below are switches rather than package-level maps for the same
 // reason: nothing may run before main.
-
-// IsEvent reports whether name is one of the six core events. Slicing the array
-// allocates nothing, so the hook path stays free of startup work.
-func IsEvent(name string) bool {
-	return slices.Contains(events[:], name)
-}
 
 // IsKind reports whether name is a canonical tool kind.
 func IsKind(name string) bool {

--- a/internal/rule/yaml.go
+++ b/internal/rule/yaml.go
@@ -274,17 +274,15 @@ func closingQuote(s string) int {
 }
 
 // unquote resolves the two quoting styles the rule format needs. s is the
-// quoted value with nothing after the closing quote.
+// quoted value with nothing after the closing quote, so its first byte is one
+// of the two quotes and there is no third style to fall through to.
 func unquote(s string) (string, error) {
-	switch s[0] {
-	case '\'':
+	if s[0] == '\'' {
 		return strings.ReplaceAll(s[1:len(s)-1], "''", "'"), nil
-	case '"':
-		v, err := strconv.Unquote(s)
-		if err != nil {
-			return "", errors.New("invalid quoted value")
-		}
-		return v, nil
 	}
-	return s, nil
+	v, err := strconv.Unquote(s)
+	if err != nil {
+		return "", errors.New("invalid quoted value")
+	}
+	return v, nil
 }

--- a/main.go
+++ b/main.go
@@ -605,8 +605,8 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Nothing below may exit non-zero on handrail's own failure: an engine that
-	// cannot answer must let the event through rather than wedge the harness.
+	// An engine that cannot answer lets the event through rather than wedge the
+	// harness, so every failure below delivers a message and never blocks.
 	failOpen := func(format string, args ...any) int {
 		return a.Deliver(event, fmt.Sprintf(format, args...), false, stdout, stderr)
 	}

--- a/main.go
+++ b/main.go
@@ -610,15 +610,16 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	failOpen := func(format string, args ...any) int {
 		return a.Deliver(event, fmt.Sprintf(format, args...), false, stdout, stderr)
 	}
-	const unreadable = "handrail: could not read the %s payload, so no rule was evaluated: %v"
-
+	// Two different faults, so two different messages: stdin never arrived, or it
+	// arrived and was not the payload. Reporting the second as the first sends the
+	// reader to look at the pipe when the harness's JSON is what to fix.
 	data, err := io.ReadAll(stdin)
 	if err != nil {
-		return failOpen(unreadable, event, err)
+		return failOpen("handrail: could not read the %s payload, so no rule was evaluated: %v", event, err)
 	}
 	payload, cwd, err := a.Normalize(event, data)
 	if err != nil {
-		return failOpen(unreadable, event, err)
+		return failOpen("handrail: could not parse the %s payload, so no rule was evaluated: %v", event, err)
 	}
 	// The payload names the directory the event happened in; the process's own is
 	// the fallback for a harness that leaves it out. That is process state rather

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"cmp"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -934,14 +935,7 @@ func printRuleset(w io.Writer, rules []*rule.Rule) error {
 			status = "disabled"
 		}
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Tier, r.Name, orDefault(r.Event, "-"), orDefault(r.Kind, "*"), r.Action, status)
+			r.Tier, r.Name, cmp.Or(r.Event, "-"), cmp.Or(r.Kind, "*"), r.Action, status)
 	}
 	return tw.Flush()
-}
-
-func orDefault(s, fallback string) string {
-	if s == "" {
-		return fallback
-	}
-	return s
 }

--- a/main.go
+++ b/main.go
@@ -610,7 +610,7 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	failOpen := func(format string, args ...any) int {
 		return a.Deliver(event, fmt.Sprintf(format, args...), false, stdout, stderr)
 	}
-	unreadable := "handrail: could not read the %s payload, so no rule was evaluated: %v"
+	const unreadable = "handrail: could not read the %s payload, so no rule was evaluated: %v"
 
 	data, err := io.ReadAll(stdin)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -605,29 +605,32 @@ func cmdHook(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Nothing below may exit non-zero on handrail's own failure: an engine that
+	// cannot answer must let the event through rather than wedge the harness.
+	failOpen := func(format string, args ...any) int {
+		return a.Deliver(event, fmt.Sprintf(format, args...), false, stdout, stderr)
+	}
+	unreadable := "handrail: could not read the %s payload, so no rule was evaluated: %v"
+
 	data, err := io.ReadAll(stdin)
-	if err == nil {
-		var payload rule.Payload
-		var cwd string
-		if payload, cwd, err = a.Normalize(event, data); err == nil {
-			// The payload names the directory the event happened in; the process's
-			// own is the fallback for a harness that leaves it out. That is process
-			// state rather than payload, so it is answered here and not in Normalize.
-			if !filepath.IsAbs(cwd) {
-				if cwd, err = os.Getwd(); err != nil {
-					return a.Deliver(event,
-						fmt.Sprintf("handrail: no working directory, so no rule was evaluated: %v", err),
-						false, stdout, stderr)
-				}
-			}
-			rs := rule.Load(cwd)
-			matched, outcome := rs.Evaluate(payload)
-			return a.Deliver(event, agentMessage(rs, matched), outcome == rule.Block, stdout, stderr)
+	if err != nil {
+		return failOpen(unreadable, event, err)
+	}
+	payload, cwd, err := a.Normalize(event, data)
+	if err != nil {
+		return failOpen(unreadable, event, err)
+	}
+	// The payload names the directory the event happened in; the process's own is
+	// the fallback for a harness that leaves it out. That is process state rather
+	// than payload, so it is answered here and not in Normalize.
+	if !filepath.IsAbs(cwd) {
+		if cwd, err = os.Getwd(); err != nil {
+			return failOpen("handrail: no working directory, so no rule was evaluated: %v", err)
 		}
 	}
-	return a.Deliver(event,
-		fmt.Sprintf("handrail: could not read the %s payload, so no rule was evaluated: %v", event, err),
-		false, stdout, stderr)
+	rs := rule.Load(cwd)
+	matched, outcome := rs.Evaluate(payload)
+	return a.Deliver(event, agentMessage(rs, matched), outcome == rule.Block, stdout, stderr)
 }
 
 // agentMessage is the wire format the hook path delivers: everything the agent

--- a/testdata/script/hook_failopen.txtar
+++ b/testdata/script/hook_failopen.txtar
@@ -17,16 +17,19 @@ stdout '^code=2$'
 stderr 'handrail block: blocker \(project-shared\)'
 stderr 'skipped the broken rule'
 
-# Malformed stdin never blocks the harness: fail open, loudly.
+# Malformed stdin never blocks the harness: fail open, loudly. The payload
+# arrived and was read; it is the JSON that is wrong, and the message has to say
+# so rather than send the reader to look at stdin.
 stdin garbage
 exec handrail hook claude PreToolUse
 ! stderr .
-stdout 'handrail: could not read the PreToolUse payload'
+stdout 'handrail: could not parse the PreToolUse payload'
+! stdout 'could not read'
 
-# Neither does empty stdin.
+# Neither does empty stdin, which is the same fault: nothing to parse.
 exec sh -c 'printf "" | handrail hook claude PreToolUse; echo code=$?'
 stdout '^code=0$'
-stdout 'could not read the PreToolUse payload'
+stdout 'could not parse the PreToolUse payload'
 
 # SessionEnd has no decision control and its JSON output is discarded, so its
 # one remaining channel is stderr, which the harness shows to the user.


### PR DESCRIPTION
A refactoring pass over the whole repo, plus the one bug the pass turned up.

The assessment came back Minor: no god functions, no dead code, no interfaces with
one implementation, no unused exports. What it did find was a stdlib
reimplementation, two vocabularies written down twice, one unreachable branch, and
one inverted control flow.

## Refactors

Behaviour-preserving. No test file changed for any of these.

- `orDefault` deleted in favour of `cmp.Or`, which has been stdlib since Go 1.22.
- `Events` and `IsEvent` now read one `events` array. The six event names were
  written out twice, so adding a seventh to one copy and not the other would have
  been silent. The array is constants, so nothing runs before `main` to build it
  and the hook path keeps paying nothing for startup: `go tool nm` shows no
  `rule.init` symbol.
- `unquote` loses a `return` its only caller cannot reach. `parseScalar` has
  already established the first byte is one of the two quotes.
- `.handrail` and `local` become `sharedName` and `localName`. Both were written
  twice, and a rename would have broken the git-exclude line and the walk's skip
  while everything still compiled. The CLI's own messages still name those paths
  in prose, so a rename remains a grep rather than a one-line edit.
- `cmdHook` reads top to bottom. The happy path sat at nesting depth four under two
  `if err == nil` blocks, and the failure path fell through relying on which of two
  assignments had left `err` set.

Net effect is about ten fewer lines of code. Not a size win: the point was the two
drift risks and the unreachable branch.

## Fix

Separating those two failure paths in `cmdHook` exposed a wrong message. A payload
that read fine but failed `Normalize` was reported as `could not read the %s
payload`, which sends the reader to look at stdin when the harness's JSON is what
to fix. `Normalize`'s only failure is `json.Unmarshal`, so the parse case now says
`could not parse`.

Both existing assertions in `hook_failopen.txtar` were pinning the inaccurate
wording: garbage JSON and empty stdin both reach `io.ReadAll` successfully and fail
inside `Normalize`. They now assert the parse message, written before the fix and
confirmed red first. The read branch stays untested, as it was before: a stdin that
errors mid-read is not something testscript can produce across a process boundary.

## Docs

`CONTEXT.md` separates Term from Condition and defines Project root. `Term` already
exists at `internal/rule/rule.go:52`; this is the vocabulary catching up to it.

## Verification

`task lint` 0 issues, `task test` green, `task cover` 97.8% against a 95% gate.
