### PR TITLE
fix(harness): PowerShell is a shell, not an unnamed tool kind

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,7 +105,7 @@ Hardcoded in Go per Adapter, next to its translation knowledge. Per-event: exist
 | Context injection | Yes | Yes (`additionalContext`) |
 | Transcript access | Yes (`transcript_path`, written asynchronously, tail may lag) | Yes (`transcript_path`) |
 | Fail-open on hook error | Yes (documented) | Yes |
-| Tool names on the wire | `Bash`, `Edit`/`Write`, `Read`, `mcp__<server>__<tool>` | The same, plus `apply_patch` for every file edit, whose whole edit rides in `tool_input.command` |
+| Tool names on the wire | `Bash`, `PowerShell`, `Edit`/`Write`, `Read`, `mcp__<server>__<tool>`. `PowerShell` is a `shell` kind carrying its command in `tool_input.command` like `Bash`; it is opt-in on Linux and macOS via `CLAUDE_CODE_USE_POWERSHELL_TOOL` | The same, plus `apply_patch` for every file edit, whose whole edit rides in `tool_input.command` |
 | Config sync writes | `~/.claude/settings.json`, or `$CLAUDE_CONFIG_DIR/settings.json` where that is set | `~/.codex/hooks.json`, or `$CODEX_HOME/hooks.json` where that is set |
 | Known bypasses | `disableAllHooks`, cloud sessions | an enterprise `allow_managed_hooks_only` requirement. `--dangerously-bypass-hook-trust` skips the trust review rather than the hooks, and `codex exec --ignore-rules` bypasses execpolicy, which costs a promoted rule (section 5) its backstop but leaves the hook path intact |
 

--- a/internal/harness/advise.go
+++ b/internal/harness/advise.go
@@ -119,6 +119,14 @@ func claudeEntries(r *rule.Rule, t rule.Term) ([]string, string, bool) {
 		}
 		// Claude Code globs a Bash pattern, so a bare value is an exact match and
 		// a trailing star is the prefix: the two operators, verbatim.
+		//
+		// ponytail: Bash only, so a promoted shell rule keeps its native backstop
+		// on one of the two shells the rule itself now reaches. PowerShell(...) is
+		// a real permission form, but a rule's command pattern is POSIX-shaped and
+		// PowerShell's command language is not, so pasting the same string under
+		// that form would author an entry denying something other than what the
+		// rule denies, which is exactly what ADR 0005 refuses. Emitting a pair
+		// needs a translation that is exact, not a second spelling of a guess.
 		if t.Op == "equals" {
 			return []string{"Bash(" + t.Value + ")"}, compoundCaveat, true
 		}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -136,6 +136,12 @@ func (a Adapter) Normalize(event string, data []byte) (rule.Payload, string, err
 // on the wire: its hooks reference documents Bash, apply_patch, and
 // mcp__<server>__<tool>, and says a model calling Edit or Write still arrives
 // as apply_patch. A name only one harness emits costs the other nothing.
+//
+// PowerShell is a shell for the same reason Bash is, and its command rides in
+// tool_input.command like Bash's: Claude Code's tools reference says so
+// outright. It is opt-in on Linux and macOS rather than absent there, and a
+// shell rule that stops firing the moment a user opts in is the failure this
+// table exists to prevent.
 func classify(tool string) string {
 	if strings.HasPrefix(tool, "mcp__") {
 		return "mcp"
@@ -143,7 +149,7 @@ func classify(tool string) string {
 	switch tool {
 	case "":
 		return ""
-	case "Bash":
+	case "Bash", "PowerShell":
 		return "shell"
 	case "Edit", "Write", "NotebookEdit", "apply_patch":
 		return "file_edit"

--- a/testdata/script/hook_claude.txtar
+++ b/testdata/script/hook_claude.txtar
@@ -9,6 +9,14 @@ stdout '^code=2$'
 stderr '^handrail block: dangerous-rm \(project-shared\)$'
 stderr 'Never delete recursively from the filesystem root'
 
+# PowerShell is the other shell Claude Code can route commands through, and it
+# carries its command in the same key, so the same shell rule reaches it. A rule
+# that stopped here would be a guardrail covering one of the two shells.
+stdin pwsh-rm.json
+exec sh -c 'handrail hook claude PreToolUse; echo code=$?'
+stdout '^code=2$'
+stderr '^handrail block: dangerous-rm \(project-shared\)$'
+
 # A warning file_edit rule matching on content: the action proceeds, the message
 # is injected as context.
 stdin write-secret.json
@@ -96,6 +104,12 @@ ref: refs/heads/main
   "cwd": "CWD",
   "hook_event_name": "PreToolUse",
   "tool_name": "Bash",
+  "tool_input": {"command": "rm -rf /tmp/build", "description": "clean"}
+}
+-- pwsh-rm.json --
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "PowerShell",
   "tool_input": {"command": "rm -rf /tmp/build", "description": "clean"}
 }
 -- bash-curl.json --


### PR DESCRIPTION
Claude Code's PowerShell tool classified as `other`, so every `kind: shell` rule silently failed to fire on a PowerShell call: a guardrail manager covering one of the two shells the harness can route commands through.

## Why it is live on handrail's targets

The tool is not Windows-only. From the tools reference:

- **Windows without Git Bash**: the tool is enabled automatically.
- **Windows with Git Bash installed**: the tool is rolling out progressively.
- **Linux, macOS, and WSL**: the tool is opt-in.

handrail ships darwin and linux, so a user who sets `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` loses every shell rule with no notice. The hooks docs tell hook authors this directly: "Match `Bash|PowerShell` in hooks that inspect shell commands."

The payload key needed no guessing either. The tools reference states it: "Your PreToolUse hooks receive the tool's command string in `tool_input.command`, with the same fields as the Bash tool." So `Normalize`'s existing `shell` branch already reads the right key and needs no change.

## What changed

- `classify` maps `Bash, PowerShell` to `shell`. Adding a Claude-only name to the shared table costs Codex nothing, which the comment above the table already establishes as the rule for it.
- `docs/spec.md` capability matrix names `PowerShell` in the tool-names row, with the opt-in variable.
- `testdata/script/hook_claude.txtar` drives a `PowerShell` payload through `hook claude PreToolUse` against the existing `dangerous-rm` rule. Shown to fail before the `classify` change (`code=0`, the rule never fired) and pass after.

## Left open on purpose

`claudeEntries` still spells only `Bash(...)`, so a promoted shell rule keeps its native backstop on one shell. `PowerShell(...)` is a real permission form, but a rule's command pattern is POSIX-shaped and PowerShell's command language is not, so pasting the same string under that form would author an entry into the user's own config denying something other than what the rule denies. ADR 0005 refuses exactly that. A `ponytail:` comment names the gap where the next reader will hit it.