### PR TITLE
test(rule): walk the operator vocabulary so parsing one implies matching it

### DIFF
--- a/internal/rule/evaluate_test.go
+++ b/internal/rule/evaluate_test.go
@@ -1,0 +1,78 @@
+// White box, because the gap this file guards is between two unexported sites
+// that no rule file can put in disagreement: everything a rule file can express
+// is tested through the compiled binary instead (ADR 0009).
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+// An operator lives at three sites: the operators list the parser accepts from,
+// the compile switch that turns a pattern into a regexp, and Term.matches,
+// which applies it. A testscript case can only exercise operators that already
+// exist at all three, so the operator added to the list and forgotten in
+// matches is the one nothing catches: it parses, it passes check, and then it
+// silently never fires, or, negated, always does. Only a walk of the list sees
+// that.
+//
+// Each value below matches the same command, so the operator is the only thing
+// under test. An operator added to the list without a value here fails on the
+// missing entry, which is the reminder to think about what matching means for
+// it.
+func TestEveryOperatorTheParserAcceptsAlsoMatches(t *testing.T) {
+	const command = "deploy prod now"
+	matching := map[string]string{
+		"matches":     `^deploy\s`,
+		"contains":    "prod",
+		"equals":      command,
+		"starts_with": "deploy",
+		"ends_with":   "now",
+		"glob":        "deploy*",
+	}
+	payload := Payload{Event: "PreToolUse", Kind: "shell", Fields: map[string]string{"command": command}}
+
+	for _, op := range operators {
+		t.Run(op, func(t *testing.T) {
+			value, ok := matching[op]
+			if !ok {
+				t.Fatalf("no value that matches %q, so this operator is untested", op)
+			}
+			// The negated spelling shares the switch and inverts the answer, so
+			// an operator missing from it reads as "always matches" there.
+			for _, c := range []struct {
+				key  string
+				want bool
+			}{{op, true}, {"not_" + op, false}} {
+				if got := parseOne(t, c.key, value).matches(payload); got != c.want {
+					t.Errorf("%s: %s matches(%q) = %v, want %v", c.key, value, command, got, c.want)
+				}
+			}
+		})
+	}
+}
+
+// parseOne builds a Term the way a rule file does, so the compile switch is on
+// the path too: an operator needing a regexp and not getting one panics in
+// matches rather than quietly missing.
+func parseOne(t *testing.T, op, value string) *Term {
+	t.Helper()
+	doc := strings.Join([]string{
+		"---",
+		"event: PreToolUse",
+		"kind: shell",
+		"conditions:",
+		"  - field: command",
+		"    " + op + ": '" + value + "'",
+		"---",
+		"Say something.",
+	}, "\n")
+	r, err := Parse("op-under-test", []byte(doc))
+	if err != nil {
+		t.Fatalf("Parse(%s: %s) = %v", op, value, err)
+	}
+	if len(r.Conditions) != 1 || r.Conditions[0].Term == nil {
+		t.Fatalf("Parse(%s) produced %d conditions, want one term", op, len(r.Conditions))
+	}
+	return r.Conditions[0].Term
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -92,13 +92,17 @@ func IsField(name string) bool {
 	return false
 }
 
+// operators is the condition vocabulary, and a list rather than a switch so a
+// test can walk it. Parsing an operator is only half of supporting one: the
+// other half is Term.matches, whose switch has no default and cannot have one
+// that fails loudly on the hot path. A seventh operator added here alone would
+// parse clean, pass check, and then never match, or, negated, always match.
+// Walking this list is what turns that into a test failure.
+var operators = []string{"matches", "contains", "equals", "starts_with", "ends_with", "glob"}
+
 // isOperator reports whether key is a condition operator, negated or not.
 func isOperator(key string) bool {
-	switch strings.TrimPrefix(key, "not_") {
-	case "matches", "contains", "equals", "starts_with", "ends_with", "glob":
-		return true
-	}
-	return false
+	return slices.Contains(operators, strings.TrimPrefix(key, "not_"))
 }
 
 // Parse reads one rule file. name is the rule's identity, the file's basename


### PR DESCRIPTION
An operator lives at three sites: the list the parser accepts from, the compile switch that turns a pattern into a regexp, and `Term.matches`, which applies it. They agree today. A seventh operator added to the accept list alone would parse clean, pass `check`, and then never match, or, negated, always match. No compile error, no test failure, and the switch in `matches` has no `default` it could fail loudly from on the hot path.

A testscript case cannot cover this. It can only exercise operators that already exist at all three sites, so the one that is missing from `matches` is precisely the one no rule file can reach. ADR 0009 allows a unit test for exactly this shape, and the `harness` package already has the precedent in `TestEveryAdapterDeclaresItsPromotionWhole`: a walk of a table that only a walk of the table can see into.

## What changed

- `isOperator`'s inline switch becomes `slices.Contains(operators, ...)` over a package-level `operators` slice. This is the part that makes the guard real: with the list as the single accept site, adding an operator means adding it here, and the test walks what it finds. A test holding its own copy of the six strings would pass right through the bug it exists to catch.
- `internal/rule/evaluate_test.go` walks `operators`, parses a real rule document per operator so the compile switch is on the path too, and asserts the term matches a payload it should, and that the `not_` spelling does not.

## Verification

Deleting `ends_with` from the switch in `evaluate.go` and nothing else fails the test in both polarities:

```
--- FAIL: TestEveryOperatorTheParserAcceptsAlsoMatches/ends_with
    ends_with: now matches("deploy prod now") = false, want true
    not_ends_with: now matches("deploy prod now") = true, want false
```
