### PR TITLE
chore: fail lint when a skill quotes a path the code no longer uses

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,10 +44,11 @@ tasks:
         print "coverage " $3 "% is under the {{.GATE}}% gate"; exit 1 } }'
 
   lint:
-    desc: golangci-lint, plus the formatter check CI runs separately
+    desc: golangci-lint, the formatter check CI runs separately, and the paths the skills quote from the code
     cmds:
       - golangci-lint run
       - golangci-lint fmt --diff
+      - scripts/check-doc-paths.sh
 
   release-check:
     desc: Validate .goreleaser.yml and the pinned version, so a bad config fails here rather than on a tag

--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# The skills are shell snippets an agent runs verbatim, so every path in them is
+# a path the code decides: where bootstrap installs the binary, and where each
+# harness keeps its state. Nothing executes a skill's copy, so a move or a
+# rename breaks skill invocation silently, at the one moment nobody is looking.
+# This is the grep that turns that into a failing lint.
+#
+# Run from the repo root, by `task lint`.
+
+set -eu
+
+status=0
+# Every mismatch is reported, so one run names every file to edit.
+mismatch() {
+	echo "$1" >&2
+	status=1
+}
+
+# The binary's install directory. bootstrap.sh is the one that creates it, so it
+# is the source of truth and the skills quote it.
+bindir=$(sed -n 's/^bindir=//p' scripts/bootstrap.sh)
+[ -n "$bindir" ] || {
+	echo "scripts/bootstrap.sh has no bindir line" >&2
+	exit 1
+}
+for skill in skills/add/SKILL.md skills/analyze/SKILL.md; do
+	grep -qF "$bindir/handrail" "$skill" ||
+		mismatch "$skill does not spell the install directory as bootstrap.sh does: $bindir"
+done
+
+# Each harness's user-level directory and the variable that relocates it. The
+# analyze skill reads transcripts out of both, so a harness added to the adapter
+# table without a line there is a harness analyze cannot see.
+adapters=internal/harness/harness.go
+pairs=$(sed -n 's/.*dir: "\([^"]*\)", homeEnv: "\([^"]*\)".*/\1 \2/p' "$adapters")
+names=$(sed -n 's/.*Name: "\([a-z]*\)",.*/\1/p' "$adapters" | grep -c .)
+found=$(echo "$pairs" | grep -c .)
+# A reformat that splits an adapter's fields across lines would leave this
+# reading fewer pairs than there are adapters, and pass by finding nothing.
+[ "$found" -eq "$names" ] || {
+	echo "$adapters has $names adapters but $found dir/homeEnv pairs on one line: fix this script's sed" >&2
+	exit 1
+}
+# Collected rather than reported inline, because a pipeline's loop body runs in
+# a subshell and could not raise status from there.
+missing=$(echo "$pairs" | while read -r dir env; do
+	grep -qF "\${$env:-\$HOME/$dir}" skills/analyze/SKILL.md ||
+		echo "skills/analyze/SKILL.md does not read \${$env:-\$HOME/$dir}, which $adapters declares"
+done)
+[ -z "$missing" ] || mismatch "$missing"
+
+exit $status


### PR DESCRIPTION
The skills are shell snippets an agent runs verbatim, so every path in them is a path the code decides. Three facts were spelled out twice with nothing binding the copies:

- `${XDG_DATA_HOME:-$HOME/.local/share}/handrail/bin`, in `scripts/bootstrap.sh` and again in both `skills/*/SKILL.md`.
- Each harness's user-level directory and relocation variable, in the adapter table in `internal/harness/harness.go` and again in `skills/analyze/SKILL.md`.

Nothing executes a skill's copy, so a move or a rename breaks skill invocation silently, at the one moment nobody is looking at it.

## What changed

`scripts/check-doc-paths.sh`, a sibling to `scripts/check-version-pin.sh` and written the same way: plain `sh`, `set -eu`, every mismatch reported so one run names every file to edit. Wired into `task lint` rather than `task release-check`, since this is not release-specific, and CI calls the same task.

It takes `bindir` from `bootstrap.sh` as the source of truth and greps both skills for it, then reads each adapter's `dir` and `homeEnv` out of the Go table and greps `analyze/SKILL.md` for the shell expression they imply. A harness added to the table without a line in the skill is a harness `analyze` cannot see, and that now fails lint.

The script also guards its own `sed`: if an adapter's `dir` and `homeEnv` stop sharing a line, the pair count no longer matches the adapter count and it exits 1, rather than passing by finding nothing.

## Verification

Breaking all three bound facts at once produces all three messages and exit 1:

```
skills/add/SKILL.md does not spell the install directory as bootstrap.sh does: ${XDG_DATA_HOME:-$HOME/.local/share}/handrail/bin
skills/analyze/SKILL.md does not read ${CLAUDE_CONFIG_DIR:-$HOME/.claude-code}, which internal/harness/harness.go declares
skills/analyze/SKILL.md does not read ${CODEX_HOME:-$HOME/.codex}, which internal/harness/harness.go declares
```

Splitting an adapter's fields across two lines produces the self-guard instead:

```
internal/harness/harness.go has 2 adapters but 1 dir/homeEnv pairs on one line: fix this script's sed
```

Shellcheck clean.

## Not covered

`skills/analyze/SKILL.md` also restates liveness as `enabled && shadowed_by == null`, which is `Rule.Live()`. That is prose a grep cannot bind, so it is left alone here.
