### PR TITLE
refactor(rule): a Condition is its Terms, and the parser flattens

### DIFF
--- a/internal/harness/advise.go
+++ b/internal/harness/advise.go
@@ -72,14 +72,9 @@ func (a Adapter) Advise(r *rule.Rule) (Advice, bool) {
 	if r.Action != rule.Block || r.Event != "PreToolUse" || len(r.Conditions) != 1 {
 		return Advice{}, false
 	}
-	terms := r.Conditions[0].Any
-	if t := r.Conditions[0].Term; t != nil {
-		terms = []rule.Term{*t}
-	}
-
-	// A deny list is a disjunction, which is exactly what an any group is, so
-	// each branch earns its own entry. One untranslatable branch sinks the rule:
-	// the remaining entries would be a guardrail with a hole in it.
+	// A deny list is a disjunction, which is exactly what a Condition's Terms
+	// are, so each branch earns its own entry. One untranslatable branch sinks
+	// the rule: the remaining entries would be a guardrail with a hole in it.
 	adv := Advice{
 		Mechanism:   p.mechanism,
 		Location:    target,
@@ -88,7 +83,7 @@ func (a Adapter) Advise(r *rule.Rule) (Advice, bool) {
 	adv.Caveats = append(adv.Caveats, silentCaveat)
 	adv.Caveats = append(adv.Caveats, p.caveats...)
 	var entries []string
-	for _, t := range terms {
+	for _, t := range r.Conditions[0].Terms {
 		spelled, caveat, ok := p.entries(r, t)
 		if !ok {
 			return Advice{}, false

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAdviseRefusesWhatItCannotSpellExactly(t *testing.T) {
-	translatable := []rule.Condition{{Term: &rule.Term{Field: "command", Op: "starts_with", Value: "git push --force"}}}
+	translatable := []rule.Condition{{Terms: []rule.Term{{Field: "command", Op: "starts_with", Value: "git push --force"}}}}
 	claude, _ := Lookup("claude")
 
 	cases := []struct {
@@ -30,9 +30,10 @@ func TestAdviseRefusesWhatItCannotSpellExactly(t *testing.T) {
 			Adapter{Name: "gemini", promotion: promotion{mechanism: "policy.deny", file: "policy.json"}},
 			translatable,
 		},
-		// A condition that names no term spells no entry, and an advice with no
-		// entry is a paste target with nothing to paste.
-		{"a condition carrying no term", claude, []rule.Condition{{}}},
+		// A condition carrying no terms spells no entry, and an advice with no
+		// entry is a paste target with nothing to paste. The parser never builds
+		// one, so this is the shape a future caller could hand Advise directly.
+		{"a condition carrying no terms", claude, []rule.Condition{{}}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/rule/evaluate.go
+++ b/internal/rule/evaluate.go
@@ -49,15 +49,9 @@ func (r *Rule) matches(p Payload) bool {
 		return false
 	}
 	for _, c := range r.Conditions {
-		if c.Term != nil {
-			if !c.Term.matches(p) {
-				return false
-			}
-			continue
-		}
 		hit := false
-		for i := range c.Any {
-			if c.Any[i].matches(p) {
+		for i := range c.Terms {
+			if c.Terms[i].matches(p) {
 				hit = true
 				break
 			}
@@ -81,7 +75,7 @@ func (t *Term) matches(p Payload) bool {
 	var hit bool
 	switch op {
 	case "matches", "glob":
-		hit = t.Re.MatchString(v)
+		hit = t.re.MatchString(v)
 	case "contains":
 		hit = strings.Contains(v, t.Value)
 	case "equals":

--- a/internal/rule/evaluate_test.go
+++ b/internal/rule/evaluate_test.go
@@ -71,8 +71,8 @@ func parseOne(t *testing.T, op, value string) *Term {
 	if err != nil {
 		t.Fatalf("Parse(%s: %s) = %v", op, value, err)
 	}
-	if len(r.Conditions) != 1 || r.Conditions[0].Term == nil {
+	if len(r.Conditions) != 1 || len(r.Conditions[0].Terms) != 1 {
 		t.Fatalf("Parse(%s) produced %d conditions, want one term", op, len(r.Conditions))
 	}
-	return r.Conditions[0].Term
+	return &r.Conditions[0].Terms[0]
 }

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -41,19 +41,25 @@ type Rule struct {
 // it.
 func (r *Rule) Live() bool { return r.Enabled && r.ShadowedBy == nil }
 
-// Condition is one entry of a rule's implicit-AND condition list: either a
-// single Term, or a one-level any group that ORs its Terms.
+// Condition is one entry of a rule's implicit-AND condition list: one or more
+// Terms, which OR together. A bare field test parses to a one-Term condition
+// and an any group to a many-Term one, so nothing downstream has to ask which
+// way the rule file wrote it.
 type Condition struct {
-	Term *Term
-	Any  []Term
+	Terms []Term
 }
 
-// Term is one operator applied to one canonical payload field.
+// Term is one operator applied to one canonical payload field. re is compiled
+// by the parser for the two pattern operators, matches and glob, in either
+// polarity, and is unexported because a pattern reaching matches without having
+// gone through the parser is a pattern nothing validated. That leaves the
+// parser as the only place a pattern Term can be built: a hand-built one is a
+// nil re, and there is no spelling of it that is merely wrong instead.
 type Term struct {
 	Field string
 	Op    string
 	Value string
-	Re    *regexp.Regexp // compiled, for matches and not_matches
+	re    *regexp.Regexp
 	line  int
 }
 
@@ -229,7 +235,7 @@ func parseConditions(list *node) ([]Condition, error) {
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, Condition{Term: t})
+			out = append(out, Condition{Terms: []Term{*t}})
 			continue
 		}
 		if len(item.mapping) != 1 {
@@ -253,7 +259,7 @@ func parseConditions(list *node) ([]Condition, error) {
 			}
 			terms = append(terms, *t)
 		}
-		out = append(out, Condition{Any: terms})
+		out = append(out, Condition{Terms: terms})
 	}
 	return out, nil
 }
@@ -301,13 +307,13 @@ func parseTerm(n *node) (*Term, error) {
 		if err != nil {
 			return nil, fmt.Errorf("line %d: invalid regexp: %w", t.line, err)
 		}
-		t.Re = re
+		t.re = re
 	case "glob":
 		re, err := globToRegexp(t.Value)
 		if err != nil {
 			return nil, fmt.Errorf("line %d: invalid glob: %w", t.line, err)
 		}
-		t.Re = re
+		t.re = re
 	}
 	return t, nil
 }


### PR DESCRIPTION
`Condition` was a union of two arms, `Term *Term` and `Any []Term`, and every reader had to ask which one it held before it could do anything. Two readers existed, and both then treated the arms identically: `Rule.matches` ran a one-element loop in one branch and an OR loop in the other, and `Advise` flattened the union back into a single slice before it could translate anything. The distinction the type made was one the rule file's syntax already carries and nothing downstream wanted.

## What changed

- `Condition` becomes one field, `Terms []Term`, which OR together. Conditions still AND together, so a matcher selects only when every one of them is satisfied.
- The parser flattens: a bare field test builds a one-Term condition, an `any:` group builds a many-Term one. Which way the rule file spelled it stops being a fact anything below the parser can observe.
- `Rule.matches` loses its branch and is one OR loop.
- `Advise` loses its flatten block and reads `r.Conditions[0].Terms` directly. The comment there now says why a deny list is a disjunction rather than how to rebuild one.
- `Term.Re` becomes unexported `re`. Only `parseTerm` writes it and only `Term.matches` reads it, so exporting it offered a caller a field it could not fill correctly. Its doc comment now says what the unexport actually buys, and that a hand-built pattern Term is a nil `re` with no merely-wrong spelling available.

## Behaviour

None changed. The two arms already evaluated the same way, parse-error line numbers come from YAML nodes rather than from `Condition`, and a zero `Condition{}` still evaluates to no-match because `hit` stays false through an empty loop.

## Verification

`task test`, `task lint` (0 issues), `task cover` at 97.7% against the 95% gate.