### PR TITLE
refactor(rule): a Payload's fields are written through SetField

### DIFF
--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -102,30 +102,30 @@ func (a Adapter) Normalize(event string, data []byte) (rule.Payload, string, err
 	if err := json.Unmarshal(data, &in); err != nil {
 		return rule.Payload{}, "", err
 	}
-	p := rule.Payload{Event: event, Kind: classify(in.ToolName), Fields: map[string]string{}}
+	p := rule.Payload{Event: event, Kind: classify(in.ToolName)}
 	switch p.Kind {
 	case "shell":
-		set(p.Fields, "command", in.ToolInput, "command")
+		set(&p, "command", in.ToolInput, "command")
 	case "file_edit":
-		set(p.Fields, "path", in.ToolInput, "file_path", "notebook_path")
-		set(p.Fields, "content", in.ToolInput, "content", "new_string", "new_source")
+		set(&p, "path", in.ToolInput, "file_path", "notebook_path")
+		set(&p, "content", in.ToolInput, "content", "new_string", "new_source")
 		// Codex passes apply_patch as a shell-like tool, so the whole edit
 		// arrives as one patch envelope under command, which its hooks reference
 		// states outright: "Bash and apply_patch use tool_input.command". Left
 		// unread, every path and content condition would silently never fire on
 		// that harness's only editing tool.
-		if patch, ok := in.ToolInput["command"].(string); ok && p.Fields["path"] == "" {
-			unwrapPatch(p.Fields, patch)
+		if patch, ok := in.ToolInput["command"].(string); ok && p.Field("path") == "" {
+			unwrapPatch(&p, patch)
 		}
 	case "file_read":
-		set(p.Fields, "path", in.ToolInput, "file_path")
+		set(&p, "path", in.ToolInput, "file_path")
 	case "mcp":
 		if server, tool, ok := strings.Cut(strings.TrimPrefix(in.ToolName, "mcp__"), "__"); ok {
-			setField(p.Fields, "server", server)
-			setField(p.Fields, "tool", tool)
+			p.SetField("server", server)
+			p.SetField("tool", tool)
 		}
 	}
-	setField(p.Fields, "prompt", in.Prompt)
+	p.SetField("prompt", in.Prompt)
 	return p, in.CWD, nil
 }
 
@@ -167,7 +167,7 @@ func classify(tool string) string {
 //
 // ponytail: first file only, because the canonical payload has one path field.
 // A per-file payload is a spec change, not an implementation one.
-func unwrapPatch(fields map[string]string, patch string) {
+func unwrapPatch(p *rule.Payload, patch string) {
 	var added []string
 	var found bool
 	for line := range strings.SplitSeq(patch, "\n") {
@@ -176,14 +176,14 @@ func unwrapPatch(fields map[string]string, patch string) {
 				break
 			}
 			found = true
-			setField(fields, "path", path)
+			p.SetField("path", path)
 			continue
 		}
 		if found && strings.HasPrefix(line, "+") {
 			added = append(added, line[1:])
 		}
 	}
-	setField(fields, "content", strings.Join(added, "\n"))
+	p.SetField("content", strings.Join(added, "\n"))
 }
 
 // patchPath reads the file a patch header names. The headers sit at column 0,
@@ -201,33 +201,14 @@ func patchPath(line string) (string, bool) {
 	return "", false
 }
 
-// setField writes a canonical field unless the value is empty, and reports
-// whether it wrote. A field the call carries empty is no answer about that
-// field rather than an answer of nothing, so it stays absent, and a condition
-// against it reads absence: no match, in either polarity. Every canonical field
-// is written here, so this is the one place that rule is spelled.
-//
-// content is deliberately not an exception, and it is the case that costs
-// something: a Write carrying content "" or an Edit carrying new_string ""
-// truncates a real file, and no content condition sees it, in either polarity.
-// Presenting the empty string instead would fire every not_contains rule
-// against text nobody wrote, which is the louder mistake and the one that
-// blocks the wrong call.
-func setField(fields map[string]string, name, value string) bool {
-	if value == "" {
-		return false
-	}
-	fields[name] = value
-	return true
-}
-
 // set copies the first key the tool input actually carries into the canonical
 // field. A key the call omits and a key it carries empty are the same answer,
 // so both fall through to the next key and, failing every key, leave the field
-// absent.
-func set(fields map[string]string, name string, input map[string]any, keys ...string) {
+// absent. Which of those two a key is, and what an empty one means, is
+// rule.Payload.SetField's answer rather than this Adapter's.
+func set(p *rule.Payload, name string, input map[string]any, keys ...string) {
 	for _, k := range keys {
-		if s, ok := input[k].(string); ok && setField(fields, name, s) {
+		if s, ok := input[k].(string); ok && p.SetField(name, s) {
 			return
 		}
 	}

--- a/internal/rule/evaluate.go
+++ b/internal/rule/evaluate.go
@@ -4,14 +4,47 @@ import "strings"
 
 // Payload is the canonical event payload a matcher is evaluated against: the
 // envelope fields a matcher can select on, plus the per-kind normalized fields.
-// A field the event does not carry is absent from Fields, and so is a field it
-// carries empty: an empty value is no answer about the field rather than an
-// answer of nothing.
+// The zero value is a valid empty payload, so an Adapter that fails to
+// normalize can return one.
+//
+// Fill one, then read it: Evaluate takes a Payload by value, and a copy shares
+// the map its fields live in, so a SetField on the copy would write through to
+// the original once that map exists and be dropped while it does not. Nothing
+// does that today, and this is the sentence saying not to start.
 type Payload struct {
-	Event  string
-	Kind   string
-	Fields map[string]string
+	Event string
+	Kind  string
+	// fields is unexported so that SetField is the only way in. The rule it
+	// enforces is a matcher's rule, so it belongs to this package rather than to
+	// each Adapter that fills a payload in.
+	fields map[string]string
 }
+
+// SetField writes a canonical field unless the value is empty, and reports
+// whether it wrote. A field the event carries empty is no answer about that
+// field rather than an answer of nothing, so it stays absent, and a condition
+// against it reads absence: no match, in either polarity.
+//
+// content is deliberately not an exception, and it is the case that costs
+// something: a Write carrying content "" or an Edit carrying new_string ""
+// truncates a real file, and no content condition sees it, in either polarity.
+// Presenting the empty string instead would fire every not_contains rule
+// against text nobody wrote, which is the louder mistake and the one that
+// blocks the wrong call.
+func (p *Payload) SetField(name, value string) bool {
+	if value == "" {
+		return false
+	}
+	if p.fields == nil {
+		p.fields = make(map[string]string)
+	}
+	p.fields[name] = value
+	return true
+}
+
+// Field reads a canonical field. Empty means the payload does not carry it,
+// which is the same answer SetField refuses to write.
+func (p Payload) Field(name string) string { return p.fields[name] }
 
 // Evaluate runs the payload against the Effective ruleset and answers with both
 // halves of what an event produces: the rules that matched, in delivery order
@@ -67,7 +100,7 @@ func (r *Rule) matches(p Payload) bool {
 // payload does not carry never matches, in either polarity: "path does not end
 // with .env" says nothing about a shell command that has no path at all.
 func (t *Term) matches(p Payload) bool {
-	v, ok := p.Fields[t.Field]
+	v, ok := p.fields[t.Field]
 	if !ok {
 		return false
 	}

--- a/internal/rule/evaluate_test.go
+++ b/internal/rule/evaluate_test.go
@@ -30,7 +30,8 @@ func TestEveryOperatorTheParserAcceptsAlsoMatches(t *testing.T) {
 		"ends_with":   "now",
 		"glob":        "deploy*",
 	}
-	payload := Payload{Event: "PreToolUse", Kind: "shell", Fields: map[string]string{"command": command}}
+	payload := Payload{Event: "PreToolUse", Kind: "shell"}
+	payload.SetField("command", command)
 
 	for _, op := range operators {
 		t.Run(op, func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -857,7 +856,7 @@ func cmdTest(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	payload := rule.Payload{Event: event, Fields: map[string]string{}}
+	payload := rule.Payload{Event: event}
 	if *fromStdin {
 		data, err := io.ReadAll(stdin)
 		if err != nil {
@@ -876,7 +875,10 @@ func cmdTest(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 	// Flags win over the payload, so one field can be varied against a capture.
-	maps.Copy(payload.Fields, fields)
+	// --field already refuses an empty value, so nothing here is dropped.
+	for k, v := range fields {
+		payload.SetField(k, v)
+	}
 	if *kind != "" {
 		payload.Kind = *kind
 	}


### PR DESCRIPTION
The canonical payload carries one invariant: a field the event carries empty is absent rather than empty, so a condition against it reads absence and does not match in either polarity. That rule lived in `harness.setField`, a private helper of one Adapter, while `Payload.Fields` was an exported map anyone could write to directly. It is a matcher's rule, and it was enforced in the one place that happened to be filling a payload in at the time.

Two other writers already existed and neither went through it: `main.go`'s `--field` loop used `maps.Copy`, and `Normalize` built the map itself.

> Depends on nothing. Overlaps #70 in `internal/rule/evaluate.go`; whichever merges second gets rebased.

## What changed

- `Payload.Fields` becomes unexported `fields`. `SetField(name, value string) bool` is the only way in and reports whether it wrote; `Field(name string) string` reads.
- `SetField` allocates the map lazily, so `rule.Payload{}` stays a valid empty payload and an Adapter that fails to normalize can still return one.
- `harness.setField` is deleted. Its rationale moves verbatim onto the new method, including the paragraph about `content` deliberately not being an exception, which is the case that costs something.
- `harness.set`'s key-fallback loop now reads `SetField`'s bool: a key carried empty falls through to the next key instead of being tested separately.
- `main.go`'s `--field` loop calls `SetField`. `--field` already refuses an empty value, so nothing is dropped.

## Behaviour

None changed. The one visible difference is internal: `Normalize` now returns a nil `fields` map when nothing normalized, where it previously returned an initialized empty one. Reads of a nil map work, nothing marshals or ranges it, and the field is unexported so no caller can reach it.

## Not covered

`Evaluate` takes a `Payload` by value, and a copy shares the map its fields live in, so a `SetField` on a copy would write through to the original once that map exists and be dropped while it does not. Nothing does that today. The type's doc comment says so rather than the signature preventing it.

## Verification

`task test`, `task lint` (0 issues), `task cover` at 97.8% against the 95% gate.