### PR TITLE
refactor(rule): trust and exclude take a Project root

### DIFF
--- a/internal/rule/exclude.go
+++ b/internal/rule/exclude.go
@@ -39,22 +39,22 @@ func hasExcludeLine(data []byte) bool {
 	return false
 }
 
-// LocalExcluded reports whether this project's exclude file holds the line, and
+// LocalExcluded reports whether a project's exclude file holds the line, and
 // names the file it read. An empty path means the project root is not a git
 // working tree, where there is nothing to exclude and therefore nothing missing.
-func (rs *Ruleset) LocalExcluded() (excluded bool, path string, err error) {
-	path, data, err := readExclude(rs.Root)
+func LocalExcluded(root string) (excluded bool, path string, err error) {
+	path, data, err := readExclude(root)
 	if err != nil || path == "" {
 		return false, "", err
 	}
 	return hasExcludeLine(data), path, nil
 }
 
-// ExcludeLocal adds the Project-personal tier to this project's own exclude
-// file, reporting whether that was new. info/exclude rather than .gitignore: the
-// tier is one user's, and the ignore rule for it is nobody else's business.
-func (rs *Ruleset) ExcludeLocal() (added bool, err error) {
-	path, data, err := readExclude(rs.Root)
+// ExcludeLocal adds the Project-personal tier to a project's own exclude file,
+// reporting whether that was new. info/exclude rather than .gitignore: the tier
+// is one user's, and the ignore rule for it is nobody else's business.
+func ExcludeLocal(root string) (added bool, err error) {
+	path, data, err := readExclude(root)
 	if err != nil || path == "" || hasExcludeLine(data) {
 		return false, err
 	}

--- a/internal/rule/load.go
+++ b/internal/rule/load.go
@@ -216,6 +216,11 @@ func load(dir string, skipLocal bool) ([]*Rule, []Problem) {
 // there is none, always as a symlink-free path. It walks up for .git rather
 // than shelling out to git: this runs on the hook hot path, where a process
 // spawn is most of the budget.
+//
+// It is also the Project root every path-keyed operation takes: Trust,
+// ExcludeLocal, LocalExcluded. Those are keyed by the root and nothing else, so
+// Load is not their prerequisite. A caller that already holds a ruleset passes
+// rs.Root; a caller that only needs the path calls this and reads no rules.
 func RepoRoot(dir string) string {
 	// Trust is keyed by path, and the cwd a harness reports need not be spelled
 	// the same way as the one handrail trust saw: /tmp and /private/tmp are one

--- a/internal/rule/trust.go
+++ b/internal/rule/trust.go
@@ -52,16 +52,16 @@ func (rs *Ruleset) TrustNotice() string {
 	return ""
 }
 
-// Trust records this ruleset's project root as trusted, reporting whether that
-// was new. The load already knows the root, so a caller holding a ruleset never
-// has to work out which path the grant is keyed by.
-func (rs *Ruleset) Trust() (added bool, err error) {
+// Trust records a project root as trusted, reporting whether that was new. The
+// grant is keyed by the root alone, so granting one needs no ruleset: reading
+// the rules is what the grant gates, not a prerequisite for making it.
+func Trust(root string) (added bool, err error) {
 	// One path per line, so a newline in a path would write a second line and
 	// grant a path nobody asked for. A directory may legally hold one.
-	if strings.Contains(rs.Root, "\n") {
-		return false, fmt.Errorf("cannot trust a path containing a newline: %q", rs.Root)
+	if strings.Contains(root, "\n") {
+		return false, fmt.Errorf("cannot trust a path containing a newline: %q", root)
 	}
-	if isTrusted(rs.Root) {
+	if isTrusted(root) {
 		return false, nil
 	}
 	file := trustFile()
@@ -75,7 +75,7 @@ func (rs *Ruleset) Trust() (added bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	if _, err := fmt.Fprintln(f, rs.Root); err != nil {
+	if _, err := fmt.Fprintln(f, root); err != nil {
 		_ = f.Close()
 		return false, err
 	}

--- a/internal/rule/trust_test.go
+++ b/internal/rule/trust_test.go
@@ -12,7 +12,7 @@ import (
 // White box: the CLI covers the trust registry end to end (ADR 0009), and what
 // is left is the one path no shell can hand the binary, because an argument
 // cannot carry a newline through argv on every platform the tests run on. A
-// ruleset built here is the only way to put such a root in front of Trust.
+// call from here is the only way to put such a root in front of Trust.
 func TestTrustRefusesAPathThatWouldWriteTwoLines(t *testing.T) {
 	state := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", state)
@@ -20,8 +20,7 @@ func TestTrustRefusesAPathThatWouldWriteTwoLines(t *testing.T) {
 
 	// A directory may legally hold a newline, and the registry is one path per
 	// line: granting this one would grant "/tmp/evil" as well.
-	rs := &Ruleset{Root: "/tmp/a\n/tmp/evil"}
-	added, err := rs.Trust()
+	added, err := Trust("/tmp/a\n/tmp/evil")
 	if err == nil {
 		t.Fatal("Trust() accepted a path containing a newline")
 	}

--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func (r *report) checkTiers(rs *rule.Ruleset) {
 // out of version control. Outside a working tree there is nothing to exclude,
 // which is not the same as an exclusion that went missing.
 func (r *report) checkExclusion(rs *rule.Ruleset) {
-	switch excluded, path, err := rs.LocalExcluded(); {
+	switch excluded, path, err := rule.LocalExcluded(rs.Root); {
 	case err != nil:
 		r.bad("cannot read the exclude file of %s: %v", rs.Root, err)
 	case path == "":
@@ -284,16 +284,19 @@ func cmdTrust(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "handrail: %v\n", err)
 		return 1
 	}
-	rs := rule.Load(cwd)
-	added, err := rs.Trust()
+	// The grant is keyed by the project root alone, so trust reads no rules:
+	// rules this machine has not trusted yet are exactly what it must not need
+	// to parse before granting them.
+	root := rule.RepoRoot(cwd)
+	added, err := rule.Trust(root)
 	if err != nil {
 		fmt.Fprintf(stderr, "handrail: %v\n", err)
 		return 1
 	}
 	if added {
-		fmt.Fprintf(stdout, "trusted %s\n", rs.Root)
+		fmt.Fprintf(stdout, "trusted %s\n", root)
 	} else {
-		fmt.Fprintf(stdout, "already trusted %s\n", rs.Root)
+		fmt.Fprintf(stdout, "already trusted %s\n", root)
 	}
 	return 0
 }
@@ -558,7 +561,7 @@ func cmdSync(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	added, err := rs.ExcludeLocal()
+	added, err := rule.ExcludeLocal(rs.Root)
 	if err != nil {
 		fmt.Fprintf(stderr, "handrail: %v\n", err)
 		return 1


### PR DESCRIPTION
`Ruleset.Trust`, `Ruleset.ExcludeLocal` and `Ruleset.LocalExcluded` were methods on `Ruleset` that read exactly one thing from it: `rs.Root`. Being methods made `Load` look like their prerequisite, and `cmdTrust` paid for that reading. Granting a repo parsed every rule in it first, including the untrusted Project-shared rules the grant exists to gate.

Nothing broke, because `Load` never writes to stdout or stderr and never fails, and `cmdTrust` read no problems it collected. It was work done to obtain a path the caller could have asked for directly.

> Independent of #70 and #71. Touches `main.go` in different regions from #71.

## What changed

- The three become free functions taking a project root.
- `cmdTrust` calls `rule.RepoRoot(cwd)` instead of `rule.Load(cwd)` and reads no rules at all.
- `checkExclusion` and `cmdSync` already hold a `Ruleset` for their own reasons and pass `rs.Root`.
- `trust_test.go` calls `rule.Trust(...)` directly rather than building a `Ruleset` to carry one string.
- `RepoRoot` gains a paragraph recording that it is the Project root these three take, and that `Load` is not their prerequisite.

## Behaviour

None changed. `Load` sets `rs.Root` to exactly `RepoRoot(cwd)` and nothing else, so `handrail trust` prints the same path. The exit-1 cases `no_home.txtar` asserts come from `Trust` and `trustFile`, not from `Load`. `trust.txtar` covers every path this touches, including the repo whose untrusted rules do not parse, where `cmdTrust` still exits 0 because it never read `rs.Problems`.

## Not covered

The symlink resolution the registry depends on, so that a grant given through `/tmp` is not absent through `/private/tmp`, moves from inside the type to caller convention: `RepoRoot` still resolves, and `Trust` now accepts any string. `cmdTrust` is the only caller and calls `RepoRoot`. `LocalExcluded`'s `(bool, string, error)` triple and the `RepoRoot` name are left alone.

## Verification

`task test`, `task lint` (0 issues), `task cover` at 97.8% against the 95% gate.