### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handrail",
   "description": "Declare an agent guardrail once, in one neutral format, and enforce it through every harness's native hooks.",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0",
   "author": {
     "name": "Leonid Svyatov",
     "email": "leonid@svyatov.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handrail",
   "description": "Declare an agent guardrail once, in one neutral format, and enforce it through every harness's native hooks.",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0",
   "author": {
     "name": "Leonid Svyatov",
     "email": "leonid@svyatov.com"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,7 +14,7 @@ set -eu
 # The version this plugin pins; equal to the plugin's own version, since the
 # manifest version is the cache key that ships a new bootstrap. Bump this and
 # the version in both manifests, .claude-plugin/ and .codex-plugin/, together.
-PIN=0.1.0-rc.1
+PIN=0.1.0
 REPO=svyatov/handrail
 
 # A binary the user's package manager owns wins, always.


### PR DESCRIPTION
The first stable release. 29 commits since `v0.1.0-rc.1`, the only tag so far.

## What changed

The three places the version is spelled, bumped together because `scripts/check-version-pin.sh` requires it: `PIN` in `scripts/bootstrap.sh`, and `version` in both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`. The manifest version is the cache key that ships a new bootstrap, so a manifest left behind installs the wrong binary.

`docs/plugin-verification.md` keeps its `v0.1.0-rc.1` headings. It is a log of what was verified on a given date, not a version to bump.

## What the tag will do

Unlike `v0.1.0-rc.1`, this one carries no prerelease indicator, so both `auto` settings in `.goreleaser.yml` flip:

- The GitHub release becomes the repo's **latest** rather than a prerelease.
- The Homebrew cask is **pushed to `svyatov/homebrew-tap`**, which is public and holds one cask per project. Every `brew install handrail` serves 0.1.0 from that point on. This is the first tag that writes to the tap at all.

`HOMEBREW_TAP_TOKEN` is present in the repo secrets, and the tap repo exists and is public.

## Verification

`task test`, `task lint` (0 issues), `scripts/check-version-pin.sh` clean.

`goreleaser check` was not run locally, because goreleaser is not installed on this machine and adding it is not worth a release bump. CI's `release-config` job runs `task release-check`, which is that check plus the pin script, so the green check on this PR covers it.