### PR TITLE
docs: add contributing, conduct, security, and report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,107 @@
+name: Bug report
+description: handrail did something other than what docs/spec.md says
+labels: [bug, needs-triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Run `handrail check` and `handrail doctor` before filing. Between them they answer most reports about a rule that did not fire, and this form asks for both.
+
+        For a security vulnerability, do not file here. Use [Report a vulnerability](https://github.com/svyatov/handrail/security/advisories/new) instead.
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened
+      description: Quote the sentence in `docs/spec.md` or the README that says so, if you can find it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: happened
+    attributes:
+      label: What happened instead
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: rule
+    attributes:
+      label: The rule file
+      description: The whole file, frontmatter and body, exactly as it is on disk. Redact values, not structure.
+      render: markdown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: harness
+    attributes:
+      label: Harness
+      description: Where handrail was running. handrail only sees an event if the harness calls its hook, so this is the first thing triage has to establish.
+      options:
+        - Claude Code
+        - Codex CLI
+        - Neither, I ran the CLI directly
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: harness-version
+    attributes:
+      label: Harness version
+      description: Name the harness here as well if you chose Other above. Free text rather than a list, because these ship faster than handrail releases.
+      placeholder: claude 2.1.217
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: handrail version
+      description: The full output of `handrail version`, which prints the version, the commit, and the build date.
+      placeholder: handrail 0.1.0 (abc1234, 2026-08-20)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How you installed it
+      description: This decides which binary you are running and how it got there.
+      options:
+        - Claude Code plugin
+        - Codex CLI plugin
+        - Homebrew
+        - go install
+        - Release tarball
+        - Built from source
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: OS and architecture
+      description: There is no Windows build. CI covers Linux and macOS, and several failure paths differ between them.
+      placeholder: macOS 15.5 arm64
+    validations:
+      required: true
+
+  - type: textarea
+    id: check
+    attributes:
+      label: Output of `handrail check`
+      description: Run it in the repository where the rule should have fired. It prints the effective ruleset with tier, shadowing, and disabling.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `handrail doctor`
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/02-proposal.yml
@@ -1,0 +1,46 @@
+name: Proposal
+description: A guardrail the rule format cannot express, or a change to the command surface
+labels: [enhancement, needs-triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        handrail is pre-1.0, and `docs/spec.md` records what was deliberately left out of v1 and why. Read that section first: a deliberate omission needs a different argument than an oversight.
+
+  - type: textarea
+    id: guardrail
+    attributes:
+      label: The guardrail you want to express
+      description: In words, as you would say it to a person. What should the agent be stopped from doing, or warned about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: attempt
+    attributes:
+      label: What you tried
+      description: The rule file you wrote and what `handrail test` or `handrail check` said about it. Leave empty only if the format offers no starting point at all.
+      render: markdown
+
+  - type: textarea
+    id: gap
+    attributes:
+      label: Why the current format cannot do it
+      description: Name the missing piece. A new event, a new kind, a new operator, a field that is not carried, an action no harness maps to.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: harnesses
+    attributes:
+      label: Which harnesses this has to reach
+      description: Where a harness cannot do what a rule asks, sync substitutes the strongest action it does support. Say if a substitution would be acceptable to you.
+      options:
+        - label: Claude Code
+        - label: Codex CLI
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: What `docs/spec.md` says today
+      description: Quote the sentence this would change or contradict, if there is one. Say so if you looked and found nothing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+CI already reports the build, the race and shuffle test run, the 95% coverage
+gate, golangci-lint, the formatter, the doc-path check, the GoReleaser config,
+and the version pin. Nothing below asks about any of that.
+
+Delete any heading you have nothing to put under. An empty section reads as an
+unanswered one.
+-->
+
+## What changes
+
+<!-- One bullet per separable part of the change. -->
+
+## Spec
+
+<!--
+docs/spec.md is the behavioural source of truth. If behaviour changed, name the
+section you updated in this pull request. If it did not change, say why the
+change is invisible to the spec.
+-->
+
+## Vocabulary and decisions
+
+<!--
+CONTEXT.md if this introduces or renames a term. A new docs/adr/ entry if this
+settles a question a future reader would otherwise reopen. Say "neither" if
+neither applies.
+-->
+
+## How it is proven
+
+<!--
+Which testdata/script/*.txtar case fails without this change. A new _test.go
+under internal/ instead needs a sentence saying what a process boundary cannot
+produce here. See docs/adr/0009-testing-strategy.md.
+-->
+
+## Harness surface
+
+<!--
+Only if this touches sync, an adapter, or the advisor. One row per harness.
+Delete the whole section otherwise.
+
+| Harness | What changes | Substitution behaviour |
+|---|---|---|
+| Claude Code | | |
+| Codex CLI | | |
+-->
+
+## Breaking
+
+<!--
+handrail is pre-1.0, so breaking is allowed and has to be stated. Does this
+change the rule file format, the nine-command surface, an exit code, or the
+JSON contract of check or advise? Say "no" if it does not.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,171 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the
+dignity, rights, and contributions of all individuals, regardless of
+characteristics including race, ethnicity, caste, color, age, physical
+characteristics, neurodiversity, disability, sex or gender, gender identity
+or expression, sexual orientation, language, philosophy or religion, national
+or social origin, socio-economic position, level of education, or other
+status. The same privileges of participation are extended to everyone who
+participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our
+community's expectations for positive behavior. We also understand that our
+words and actions may be interpreted differently than we intend based on
+culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each
+other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways
+   of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our
+   community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances,
+threats, and promotion of these behaviors are violations of this Code of
+Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in
+   unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments
+   directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or
+   behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered
+   inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or
+   private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other
+   harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or
+   pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of
+   content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in
+   a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content
+   which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their
+best to collaborate. Not every conflict represents a code of conduct
+violation, and this Code of Conduct reinforces encouraged behaviors and norms
+that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report
+a possible violation, email Leonid Svyatov at leonid@svyatov.com. handrail has
+one maintainer, so he is the Community Moderator referred to below and reads
+every report himself. If your report concerns him, say so in the subject line;
+he will recuse himself from deciding the outcome and ask an uninvolved third
+party to review it instead.
+
+Community Moderators take reports of violations seriously and will make every
+effort to respond in a timely manner. They will investigate all reports of
+code of conduct violations, reviewing messages, logs, and recordings, or
+interviewing witnesses and other participants. Community Moderators will keep
+investigation and enforcement actions as transparent as possible while
+prioritizing safety and confidentiality. In order to honor these values,
+enforcement actions are carried out in private with the involved parties, but
+communicating to the whole community may be part of a mutually agreed upon
+resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of
+Conduct has been violated, the following enforcement ladder may be used to
+determine how best to repair harm, based on the incident's impact on the
+individuals involved and the community as a whole. Depending on the severity
+of a violation, lower rungs on the ladder may be skipped.
+
+### 1. Warning
+
+- **Event:** A violation involving a single incident or series of incidents.
+- **Consequence:** A private, written warning from the Community Moderators.
+- **Repair:** Examples of repair include a private written apology,
+  acknowledgement of responsibility, and seeking clarification on expectations.
+
+### 2. Temporarily Limited Activities
+
+- **Event:** A repeated incidence of a violation that previously resulted in a
+  warning, or the first incidence of a more serious violation.
+- **Consequence:** A private, written warning with a time-limited cooldown
+  period designed to underscore the seriousness of the situation and give the
+  community members involved time to process the incident. The cooldown period
+  may be limited to particular communication channels or interactions with
+  particular community members.
+- **Repair:** Examples of repair may include making an apology, using the
+  cooldown period to reflect on actions and impact, and being thoughtful about
+  re-entering community spaces after the period is over.
+
+### 3. Temporary Suspension
+
+- **Event:** A pattern of repeated violation which the Community Moderators
+  have tried to address with warnings, or a single serious violation.
+- **Consequence:** A private written warning with conditions for return from
+  suspension. In general, temporary suspensions give the person being
+  suspended time to reflect upon their behavior and possible corrective
+  actions.
+- **Repair:** Examples of repair include respecting the spirit of the
+  suspension, meeting the specified conditions for return, and being thoughtful
+  about how to reintegrate with the community when the suspension is lifted.
+
+### 4. Permanent Ban
+
+- **Event:** A pattern of repeated code of conduct violations that other steps
+  on the ladder have failed to resolve, or a violation so serious that the
+  Community Moderators determine there is no way to keep the community safe
+  with this person as a member.
+- **Consequence:** Access to all community spaces, tools, and communication
+  channels is removed. In general, permanent bans should be rarely used, should
+  have strong reasoning behind them, and should only be resorted to if working
+  through other remedies has failed to change the behavior.
+- **Repair:** There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the
+ability of Community Managers to use their discretion and judgment, in keeping
+with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public or other
+spaces. Examples of representing our community include using an official email
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0,
+permanently available at
+https://www.contributor-covenant.org/version/3/0/
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and
+licensed under CC BY-SA 4.0. To view a copy of this license, visit
+https://creativecommons.org/licenses/by-sa/4.0/
+
+For answers to common questions about Contributor Covenant, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are provided at
+https://www.contributor-covenant.org/translations. Additional enforcement and
+community guideline resources can be found at
+https://www.contributor-covenant.org/resources. The enforcement ladder was
+inspired by the work of Mozilla's code of conduct team at
+https://github.com/mozilla/inclusion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to handrail
+
+Contributions are welcome. This file says what you need installed, what to run
+before you push, and what a change has to satisfy to be merged.
+
+## What a change has to satisfy
+
+Two documents decide whether a change is acceptable:
+
+- [`docs/spec.md`](docs/spec.md) is the behavioural source of truth. A change
+  that alters behaviour changes the spec in the same pull request, and a change
+  the spec forbids is not merged whatever the code does.
+- [`CLAUDE.md`](CLAUDE.md) states the two constraints the build enforces: zero
+  third-party runtime dependencies, and `os.Exit` only in `main.go`. Both are
+  checked by the linter, so breaking either fails CI rather than review.
+
+[`CONTEXT.md`](CONTEXT.md) defines the vocabulary. Use its words for types and
+identifiers rather than inventing synonyms.
+
+## Setup
+
+You need [Go](https://go.dev/dl/) at the version in `go.mod`, currently 1.26.6,
+and [Task](https://taskfile.dev/installation/). Then:
+
+```bash
+git clone https://github.com/svyatov/handrail.git
+cd handrail
+task build
+```
+
+Linting additionally needs [golangci-lint](https://golangci-lint.run/docs/welcome/install/)
+v2.12.2, and `task release-check` needs [GoReleaser](https://goreleaser.com/install/).
+Neither is in `go.mod` on purpose: a tool directive would put roughly 200 modules
+into a `go.sum` whose first promise is zero third-party dependencies.
+
+## Before you push
+
+```bash
+task test    # go test -race -shuffle=on ./...
+task cover   # the same run with coverage, fails under 95%
+task lint    # golangci-lint run, then the formatter check and the doc-path check
+```
+
+CI runs these same tasks, so a local pass means what a green check means.
+
+## Tests
+
+A change that adds functionality arrives with a test.
+
+testscript over the compiled binary is the primary seam. A new case is a file in
+[`testdata/script/`](testdata/script/), not a new `_test.go`. Unit tests under
+`internal/` are only for what a process boundary cannot produce.
+[`docs/adr/0009-testing-strategy.md`](docs/adr/0009-testing-strategy.md) says why.
+
+## Opening a pull request
+
+Fork the repository, branch from `main`, and open the pull request against
+`main`. Branch names follow the commit types: `feat/`, `fix/`, `docs/`,
+`refactor/`, `chore/`, each with a kebab-case description, as in
+`fix/sync-ignores-config-dir`.
+
+Commits use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+`type(scope): description`. Pull requests are squash-merged, and the branch is
+deleted on merge.
+
+The pull request template asks for what CI cannot report. Delete any heading you
+have nothing to put under.
+
+## Reporting bugs and asking questions
+
+Both go to [GitHub issues](https://github.com/svyatov/handrail/issues). The bug
+template asks for the output of `handrail check` and `handrail doctor`; run both
+before filing, because between them they answer most reports about a rule that
+did not fire.
+
+Security vulnerabilities do not go to the issue tracker. See
+[SECURITY.md](SECURITY.md).
+
+## Who decides
+
+Leonid Svyatov ([@svyatov](https://github.com/svyatov)) is the sole maintainer.
+He reviews and merges every change and cuts every release. There is no
+succession arranged: if he stops, nobody else currently has commit or release
+access, and the project would need a fork to continue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub, at
+[Security, Report a vulnerability](https://github.com/svyatov/handrail/security/advisories/new).
+The report is visible only to the maintainer until an advisory is published.
+
+Do not open a public issue for a vulnerability.
+
+You will get a first response within 14 days. That response says whether the
+report is accepted, and if it is, what the fix and disclosure timeline looks
+like. If 14 days pass with no reply, open a public issue saying only that a
+private report is awaiting a response, with no details of the vulnerability
+itself.
+
+## What is in scope
+
+handrail runs as a hook inside a coding agent harness and decides whether a
+tool call is allowed. Reports of the following are in scope:
+
+- A rule that should block a tool call but does not, or that can be made not to.
+- A path through `handrail sync` that writes a harness configuration the rule
+  files did not ask for.
+- A committed `.handrail/` ruleset taking effect without `handrail trust`.
+- Anything that lets a rule file execute code, read a file, or reach the network.
+- A flaw in the plugin bootstrap's download or checksum verification.
+
+Out of scope: a harness that never calls the hook, and a rule that is simply
+written wrong. Both are ordinary issues.
+
+## Supported versions
+
+handrail is pre-1.0. Only the latest release gets fixes; there are no backports
+to earlier tags.


### PR DESCRIPTION
## What changes

- `CONTRIBUTING.md`: the Taskfile commands, the fork and branch workflow, that a change adding functionality arrives with a test, and the two documents an acceptable change has to satisfy. Its closing section states that handrail has one maintainer and no succession arranged.
- `CODE_OF_CONDUCT.md`: Contributor Covenant 3.0, fetched from the steward, attribution and CC BY-SA notice intact. Reporting goes to leonid@svyatov.com, with a recusal clause for a report about the maintainer.
- `SECURITY.md`: private vulnerability reporting, a 14 day first response, and what is in scope. A harness that never calls the hook and a rule written wrong are named out of scope, because both arrive as security reports otherwise.
- `.github/ISSUE_TEMPLATE/01-bug.yml`: an issue form requiring the harness, the harness version, the handrail version, the install method, the platform, the rule file, and the output of `handrail check` and `handrail doctor`.
- `.github/ISSUE_TEMPLATE/02-proposal.yml`: an issue form for a guardrail the rule format cannot express.
- `.github/pull_request_template.md`: sections for what CI cannot report. It asks nothing about the build, the tests, the coverage gate, or the linter.

The harness and its version are the fields a solo maintainer cannot derive from their own reproduction. Without them a report cannot tell a wrong rule from a hook Codex is still holding for approval.

## Spec

No behaviour change. Nothing in `docs/spec.md` moves, because no code changes.

## Vocabulary and decisions

Neither. The files use the terms `CONTEXT.md` already defines.

## How it is proven

No `testdata/script` case, because no code path changes. What was checked instead:

- Both issue forms parse as YAML and every element carries a `type`.
- Every URL in the new files returns 200, including the advisory form, which resolves only because private vulnerability reporting is now enabled on the repository.
- No placeholder text survives from the Covenant template.
- `scripts/check-doc-paths.sh` exits 0.
- The `oss-writing` prose linter reports only Title Case headings inside `CODE_OF_CONDUCT.md`, which R-DOC-05 exempts as headings preserved from an attributed third-party document.

The issue forms reach the template chooser only once this lands on `main`, so their rendering is unverified until then.

## Breaking

No. No change to the rule format, the command surface, an exit code, or the JSON contract of `check` or `advise`.
