### PR TITLE
docs: add a changelog covering both published tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+handrail is pre-1.0, so a MINOR bump may break you and a PATCH bump will not.
+The public surface is the command set, the rule file format, and the exit codes,
+all of which [`docs/spec.md`](docs/spec.md) states.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-20
+
+First release. One rule file, enforced in Claude Code and in Codex CLI through
+each harness's own hook mechanism.
+
+### Added
+
+- Rules as markdown files: the matcher in the frontmatter, the message the agent
+  reads in the body.
+- Three tiers, most specific first: project-personal `.handrail/local/`,
+  project-shared `.handrail/`, and global `~/.config/handrail/`. A rule replaces
+  a lower one of the same filename outright, and a stub carrying
+  `enabled: false` switches an inherited rule off.
+- `handrail check` validates every tier and prints the effective ruleset,
+  annotated with tier, shadowing, and disabling.
+- `handrail test <event>` dry-runs one synthetic event against the rules and
+  exits 2 when the outcome is block.
+- `handrail sync` writes handrail's hook entries into every detected harness.
+  Where a harness cannot do what a rule asks, it substitutes the strongest
+  action that harness supports and reports the substitution rather than
+  degrading the rule silently.
+- `handrail advise` reports which rules also translate into a native harness
+  entry, such as a Claude Code permission deny.
+- `handrail trust` grants a repo's committed `.handrail/` rules permission to
+  take effect.
+- `handrail import hookify` converts hookify rule files into personal rules and
+  reports anything the format cannot express.
+- `handrail doctor` diagnoses the install offline.
+- `handrail version` prints the version, commit, and build date.
+- `handrail hook` is the entry point the harnesses call. Sync installs it.
+- Plugins for Claude Code and Codex CLI from the repo's own marketplace,
+  carrying the `add` skill. The plugin downloads the pinned binary on the next
+  session start, verifies its checksum, and syncs once.
+- Prebuilt binaries for macOS and Linux on amd64 and arm64, and a Homebrew cask
+  at `svyatov/tap/handrail`. There is no Windows build.
+
+## [0.1.0-rc.1] - 2026-08-18
+
+Prerelease that proved the release pipeline end to end: the GoReleaser build,
+the checksum manifest, and the tap cask. The Claude Code and Codex CLI plugins
+landed after it, in 0.1.0.
+
+[unreleased]: https://github.com/svyatov/handrail/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/svyatov/handrail/compare/v0.1.0-rc.1...v0.1.0
+[0.1.0-rc.1]: https://github.com/svyatov/handrail/releases/tag/v0.1.0-rc.1


### PR DESCRIPTION
## What changes

- `CHANGELOG.md` in Keep a Changelog 2.0.0, with an entry for `v0.1.0` and one for `v0.1.0-rc.1`, backfilled from the two tags the repository has.
- The preamble declares the versioning policy, which was stated nowhere before: pre-1.0, a MINOR bump may break you and a PATCH bump will not. The public surface is the command set, the rule file format, and the exit codes.
- `[Unreleased]` is empty. The two commits since `v0.1.0` are #76 and #77, both documentation, so nothing a user installs has changed.

## Spec

Behaviour did not change. This adds a file that describes releases already published, so `docs/spec.md` is untouched.

## Vocabulary and decisions

Neither. One thing here is close to a decision and is recorded in the commit body instead: the plugin manifests are not a second release unit. `scripts/bootstrap.sh` pins the version the plugin downloads, and `task release-check` holds that pin equal to both manifest versions, so one changelog section covers the tag and all three files.

## How it is proven

No test case. No code path changed, so there is nothing a `testdata/script/*.txtar` case could fail on.

## Breaking

No.

## Left out

GoReleaser builds the release body from the git log rather than from this file, so the changelog does not yet reach the releases page. Wiring `--release-notes` into `.goreleaser.yml` is its own change.