### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handrail",
   "description": "Declare an agent guardrail once, in one neutral format, and enforce it through every harness's native hooks.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Leonid Svyatov",
     "email": "leonid@svyatov.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handrail",
   "description": "Declare an agent guardrail once, in one neutral format, and enforce it through every harness's native hooks.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Leonid Svyatov",
     "email": "leonid@svyatov.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ all of which [`docs/spec.md`](docs/spec.md) states.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-20
+
 ### Added
 
 - Every release archive now ships an SPDX SBOM beside it, named
@@ -68,6 +70,7 @@ Prerelease that proved the release pipeline end to end: the GoReleaser build,
 the checksum manifest, and the tap cask. The Claude Code and Codex CLI plugins
 landed after it, in 0.1.0.
 
-[unreleased]: https://github.com/svyatov/handrail/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/svyatov/handrail/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/svyatov/handrail/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/svyatov/handrail/compare/v0.1.0-rc.1...v0.1.0
 [0.1.0-rc.1]: https://github.com/svyatov/handrail/releases/tag/v0.1.0-rc.1

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,7 +14,7 @@ set -eu
 # The version this plugin pins; equal to the plugin's own version, since the
 # manifest version is the cache key that ships a new bootstrap. Bump this and
 # the version in both manifests, .claude-plugin/ and .codex-plugin/, together.
-PIN=0.1.0
+PIN=0.2.0
 REPO=svyatov/handrail
 
 # A binary the user's package manager owns wins, always.


### PR DESCRIPTION
## What changes

- `CHANGELOG.md`: the `[Unreleased]` entries become `[0.2.0] - 2026-08-20`, with
  the comparison links moved on.
- `scripts/bootstrap.sh` pins 0.2.0, and both plugin manifests carry it as their
  cache key. `scripts/check-version-pin.sh` fails when the three disagree.

A MINOR rather than a PATCH. The SBOM and the provenance attestation are new
things a downloader can use, so they are added functionality, even though the
public surface this project declares, the command set, the rule file format, and
the exit codes, is untouched.

## Spec

No behaviour change. This dates a section and moves three version strings; the
behaviour it releases landed in #80, which updated `docs/spec.md` section 9.

## Vocabulary and decisions

Neither.

## How it is proven

`task release-check` passes with the new pin: `goreleaser check` validates the
config, `scripts/check-version-pin.sh` confirms the three versions agree, and
`scripts/release-notes.sh` with no argument now resolves 0.2.0 and returns a
non-empty section, which is the body the tag will publish.

## Breaking

No.
