### PR TITLE
build(release): attest with actions/attest v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       contents: write # create the release and upload assets
       id-token: write # the short-lived OIDC token the attestation is signed with
       attestations: write # record the provenance of each asset on the repository
+      artifact-metadata: write # write the storage record actions/attest v4 creates
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -51,7 +52,7 @@ jobs:
       # The signed tag covers the commit, not the files uploaded under it. This
       # is what a downloader verifies the archives themselves against, with
       # `gh attestation verify <file> --repo svyatov/handrail`.
-      - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      - uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: |
             dist/*.tar.gz


### PR DESCRIPTION
Replaces the build-provenance step's action.

`actions/attest-build-provenance` v3.0.0 was written into `release.yml` when the
attestation step was added. Upstream marks that action a wrapper over
`actions/attest` and sends new workflows to `actions/attest` directly; v4 of the
wrapper is a composite action whose only step calls `actions/attest`. It was also
a major behind, since v4.2.2 of both had been published twelve days earlier.

`actions/attest` v4 documents `artifact-metadata: write` beside `id-token` and
`attestations`, for the storage record it creates, so the release job now grants
it.

The `subject-path` list is unchanged, so every archive, every SBOM, and
`checksums.txt` stays a subject in its own right.

## Verification

`task release-check` passes. The attestation itself only runs on a `v*` tag, so
the next release is where it is confirmed:
`gh attestation verify handrail_<version>_darwin_arm64.tar.gz --repo svyatov/handrail`
must exit 0 with a certificate naming
`.github/workflows/release.yml@refs/tags/v<version>`.

Supersedes #81, which bumped the wrapper rather than replacing it.